### PR TITLE
Update Dockerfile Go image to 1.24.2-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a base Go image to build your application
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24.2-alpine AS builder
 
 # Install git for fetching Go dependencies
 RUN apk add --no-cache git


### PR DESCRIPTION
Potential fix for crash with Docker Image. 

[crash_2025_04_26.txt](https://github.com/user-attachments/files/19924397/crash_2025_04_26.txt)

[docker_build.txt](https://github.com/user-attachments/files/19924398/docker_build.txt)

