### PR TITLE
Fix chat downloader sending duplicate messages

### DIFF
--- a/python/fetch_chat.py
+++ b/python/fetch_chat.py
@@ -4,6 +4,8 @@ import sys
 
 
 def fetch_chat(url, message_groups=None):
+    # Track which messages have been seen before
+    seen = {}
     try:
         chat_downloader = ChatDownloader()
         while True:
@@ -15,6 +17,12 @@ def fetch_chat(url, message_groups=None):
             )
             assert chat is not None, "chat is None"
             for message in chat:
+                id = message["message_id"]
+                if seen.get(id, False):
+                    continue
+                else:
+                    seen[id] = True
+
                 # Initialize default color (grey for YouTube non-members)
                 color = "#808080"
 


### PR DESCRIPTION
Chat downloader is currently pulling duplicate messages due to a bug with the inactivity_timeout setting (which is necessary to allow reconnect).

This fixes it by keeping track of seen message ids, and prevents a memory leak by deleting any seen message ids older than an hour.