### PR TITLE
Enable prod sourcemaps

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [sveltekit()],
+  build: {
+    sourcemap: true
+  },
   test: {
     workspace: [
       {


### PR DESCRIPTION
This helps us debug frontend errors in prod much more easily.