### PR TITLE
Retry logic for elora chat service

### DIFF
--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -34,7 +34,7 @@ func main() {
 		port = "8080" // Default to port 8080 if not specified
 	}
 
-	routes.InitRoutes()
+	routes.InitRoutes(2 * time.Second)
 
 	r := mux.NewRouter()
 


### PR DESCRIPTION
Adds a retry loop for pinging the redis DB. Helpful when testing locally.