### PR TITLE
Emote gap and wide emotes

### DIFF
--- a/src/frontend/src/lib/components/ChatMessage.svelte
+++ b/src/frontend/src/lib/components/ChatMessage.svelte
@@ -88,9 +88,13 @@
 
     .emote-image {
       height: 28px;
-      width: 28px;
+      margin: 0px 0.2rem; /* top/bottom left/right */
 
       vertical-align: middle;
+    }
+
+    .message-text > img + img {
+      margin-left: 0px;
     }
   }
 


### PR DESCRIPTION
## Gap (Before/After)
<p align="center">
  <img alt="Gap Before" src="https://github.com/user-attachments/assets/834c1ea3-7fde-4242-a915-71936904995b" width="45%">
&nbsp;
  <img alt="Gap After" src="https://github.com/user-attachments/assets/239544c2-dea9-48b5-bd47-e4f4cae0c5d4" width="45%">
</p>


## Wide (Before/After)
<p align="center">
  <img alt="Width Before" src="https://github.com/user-attachments/assets/aeddaf19-4170-4ad2-9508-057e09a04dbe" width="45%">
&nbsp;
  <img alt="Width After" src="https://github.com/user-attachments/assets/30171893-0201-4b6d-a42a-c36843190724" width="45%">
</p>
