### PR TITLE
Remove gap between emotes, just around them

### DIFF
--- a/src/frontend/src/lib/components/ChatMessage.svelte
+++ b/src/frontend/src/lib/components/ChatMessage.svelte
@@ -88,13 +88,17 @@
 
     .emote-image {
       height: 28px;
-      margin: 0px 0.2rem; /* top/bottom left/right */
+      margin: 0 0.2rem; /* top/bottom left/right */
 
       vertical-align: middle;
     }
 
     .message-text > img + img {
-      margin-left: 0px;
+      margin-left: 0;
+    }
+
+    .message-text > img:has(+ img) {
+      margin-right: 0;
     }
   }
 


### PR DESCRIPTION
Some emotes are designed to be smashed together. So, emotes should just have margins when adjacent to text.