### PR TITLE
Remove @ symbol from youtube chatter names

### DIFF
--- a/python/fetch_chat.py
+++ b/python/fetch_chat.py
@@ -42,7 +42,7 @@ def fetch_chat(url, message_groups=None):
                     author = message["author"]["display_name"]
                     color = message["colour"]
                 else:  # YouTube messages
-                    author = message["author"]["name"]
+                    author = message["author"]["name"][1:]
                     for badge in message["author"].get("badges", []):
                         title = badge["title"].lower()
                         if "owner" in title:


### PR DESCRIPTION
YouTube has changed their website. Names now contain a leading @ symbol. This removes it in the chat-downloader script.