### PR TITLE
fix(ui): load app.css from root layout

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,0 +1,8 @@
+<script>
+  // (optional) root layout script space
+</script>
+
+<slot />
+
+<!-- Import global stylesheet for the whole app -->
+<style global src="../app.css"></style>


### PR DESCRIPTION
Root layout now imports app.css globally so the screen-reader-only <h1> is visually hidden via .visually-hidden. Keeps a11y test green but removes visible 'Elora Chat' header.