### PR TITLE
fix(ui): load app.css before slot

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -4,5 +4,5 @@
 
 <slot />
 
-<!-- Import global stylesheet for the whole app -->
+<!-- Import global stylesheet for the whole app FIRST -->
 <style global src="../app.css"></style>


### PR DESCRIPTION
Moves <style global src='../app.css'> before <slot /> so .visually-hidden is available when <h1> renders; prevents visible 'Elora Chat' header.