### PR TITLE
feat(storage/sessions): move session state to SQLite (PR3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The backend stores chat history in Redis streams by default. To try the SQLite i
 2. (Optional) Adjust the database settings with `ELORA_DB_MODE`, `ELORA_DB_PATH`, `ELORA_DB_MAX_CONNS`, `ELORA_DB_BUSY_TIMEOUT_MS`, and `ELORA_DB_PRAGMAS_EXTRA`. Ephemeral mode (the default) leaves `ELORA_DB_PATH` empty and automatically creates a temp database such as `/tmp/elora-chat-<pid>.db`.
 3. Restart the backend. In `persistent` mode set `ELORA_DB_PATH` to a writable location (for example `./data/elora-chat.db` or `/data/elora-chat.db` when using a Docker volume like `-v elora_sqlite_data:/data`).
 
+When SQLite is selected, authentication sessions are also stored there, so Redis is optional for the backend.
+
 Write-ahead logging, foreign keys, and sensible busy timeouts are enabled automatically via connection pragmas during startup.
 
 ## Usage ⌨️

--- a/src/backend/internal/storage/sqlite/migrations/0002_sessions.sql
+++ b/src/backend/internal/storage/sqlite/migrations/0002_sessions.sql
@@ -1,0 +1,8 @@
+-- 0002_sessions.sql
+CREATE TABLE IF NOT EXISTS sessions(
+  token TEXT PRIMARY KEY,
+  service TEXT NOT NULL,
+  data_json TEXT NOT NULL,
+  token_expiry INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/src/backend/internal/storage/storage.go
+++ b/src/backend/internal/storage/storage.go
@@ -16,6 +16,15 @@ type Message struct {
 	RawJSON    string
 }
 
+// Session represents auth/session state persisted by the backend.
+type Session struct {
+	Token       string
+	Service     string
+	DataJSON    string
+	TokenExpiry time.Time
+	UpdatedAt   time.Time
+}
+
 // QueryOpts defines filters for retrieving stored messages.
 type QueryOpts struct {
 	Limit    int
@@ -24,11 +33,14 @@ type QueryOpts struct {
 	Username *string
 }
 
-// Store describes a backend capable of persisting chat messages.
+// Store describes a backend capable of persisting chat messages and sessions.
 type Store interface {
 	Init(ctx context.Context) error
 	InsertMessage(ctx context.Context, m *Message) error
 	GetRecent(ctx context.Context, q QueryOpts) ([]Message, error)
 	PurgeAll(ctx context.Context) error
+	GetSession(ctx context.Context, token string) (*Session, error)
+	UpsertSession(ctx context.Context, s *Session) error
+	DeleteSession(ctx context.Context, token string) error
 	Close(ctx context.Context) error
 }


### PR DESCRIPTION
## Summary
- Introduces a `Session` model and CRUD on the storage interface.
- Implements SQLite-backed session persistence (ephemeral & persistent modes).
- Updates auth/send routes to use storage sessions (keeps JSON payload intact).
- Makes Redis optional; guarded init; Twitch messaging reads sessions via storage.
- Adds SQLite session tests (ephemeral/persistent) and documents env defaults.

## Testing
- `cd src/backend && go test ./...` passes.
- Docker (Redis): baseline sanity OK.
- Docker (SQLite ephemeral): blank `ELORA_DB_PATH` logs `mode=ephemeral` and WAL.
- Docker (SQLite persistent): `ELORA_DB_PATH=/data/elora.db` + volume; logs `mode=persistent` and WAL.
