### PR TITLE
feat(api): recent messages endpoint + SQLite-backed history (PR4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ PORT=8080
 DEPLOYED_URL=https://localhost:8080/
 
 # Storage configuration
-# redis (default) | sqlite
-ELORA_STORE=redis
+# redis | sqlite (default)
+ELORA_STORE=sqlite
 # ephemeral (default, auto temp file) | persistent
 ELORA_DB_MODE=ephemeral
 # Leave blank for ephemeral mode (temp file under /tmp).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Redis remains supported via `ELORA_STORE=redis` if you prefer streams, but it is
 
 Write-ahead logging, foreign keys, and sensible busy timeouts are enabled automatically via connection pragmas during startup.
 
+### HTTP: recent messages
+
+Recent chat history can be fetched directly from the backend with `GET /api/messages`.
+
+Query parameters:
+
+- `limit` (optional, default 100, maximum 500)
+- `since_ts` (optional, RFC3339 timestamp or Unix epoch milliseconds)
+
+Examples:
+
+```bash
+curl "http://localhost:8080/api/messages?limit=20"
+curl "http://localhost:8080/api/messages?since_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)&limit=50"
+```
+
 ## Usage ⌨️
 
 elora-chat is easy to use. Simply start the server and connect your streaming platforms. The chat will be unified and available in your dashboard for a seamless streaming experience.

--- a/README.md
+++ b/README.md
@@ -32,21 +32,20 @@ Inspired by pioneers like DougDoug, elora-chat aspires to revolutionize chat int
 
 - Ensure [Docker](https://docs.docker.com/get-started/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/linux/) are installed and configured.
 
-- Create environment variables: `echo "REDIS_ADDR=redis:6379\nREDIS_PASSWORD=\nTWITCH_CLIENT_ID=\nTWITCH_CLIENT_SECRET=\nTWITCH_REDIRECT_URL=\nYOUTUBE_API_KEY=\nPORT=8080\nDEPLOYED_URL=https://localhost:8080/\nELORA_STORE=redis\nELORA_DB_MODE=ephemeral\nELORA_DB_PATH=\nELORA_DB_MAX_CONNS=16\nELORA_DB_BUSY_TIMEOUT_MS=5000\nELORA_DB_PRAGMAS_EXTRA=mmap_size=268435456,cache_size=-100000,temp_store=MEMORY" > .env`
+- Create environment variables: `echo "REDIS_ADDR=redis:6379\nREDIS_PASSWORD=\nTWITCH_CLIENT_ID=\nTWITCH_CLIENT_SECRET=\nTWITCH_REDIRECT_URL=\nYOUTUBE_API_KEY=\nPORT=8080\nDEPLOYED_URL=https://localhost:8080/\nELORA_STORE=sqlite\nELORA_DB_MODE=ephemeral\nELORA_DB_PATH=\nELORA_DB_MAX_CONNS=16\nELORA_DB_BUSY_TIMEOUT_MS=5000\nELORA_DB_PRAGMAS_EXTRA=mmap_size=268435456,cache_size=-100000,temp_store=MEMORY" > .env`
 
 - Start the server: `docker compose up`
 
 - Connect with your broswer to [http://localhost:8080/](http://localhost:8080/)!
 
-## SQLite storage (optional) 🗄️
+## SQLite storage (default) 🗄️
 
-The backend stores chat history in Redis streams by default. To try the SQLite implementation instead:
+The backend now persists chat history to SQLite by default. Ephemeral mode keeps everything in a temp file so you can run without any extra setup. To customize the database:
 
-1. Set `ELORA_STORE=sqlite` in your `.env` file or deployment environment.
-2. (Optional) Adjust the database settings with `ELORA_DB_MODE`, `ELORA_DB_PATH`, `ELORA_DB_MAX_CONNS`, `ELORA_DB_BUSY_TIMEOUT_MS`, and `ELORA_DB_PRAGMAS_EXTRA`. Ephemeral mode (the default) leaves `ELORA_DB_PATH` empty and automatically creates a temp database such as `/tmp/elora-chat-<pid>.db`.
-3. Restart the backend. In `persistent` mode set `ELORA_DB_PATH` to a writable location (for example `./data/elora-chat.db` or `/data/elora-chat.db` when using a Docker volume like `-v elora_sqlite_data:/data`).
+1. Adjust `ELORA_DB_MODE`, `ELORA_DB_PATH`, `ELORA_DB_MAX_CONNS`, `ELORA_DB_BUSY_TIMEOUT_MS`, and `ELORA_DB_PRAGMAS_EXTRA` as needed. Leaving `ELORA_DB_PATH` blank in `ephemeral` mode automatically creates a temp database such as `/tmp/elora-chat-<pid>.db`.
+2. Restart the backend after changing settings. In `persistent` mode set `ELORA_DB_PATH` to a writable location (for example `./data/elora-chat.db` or `/data/elora-chat.db` when using a Docker volume like `-v elora_sqlite_data:/data`).
 
-When SQLite is selected, authentication sessions are also stored there, so Redis is optional for the backend.
+Redis remains supported via `ELORA_STORE=redis` if you prefer streams, but it is no longer required for chat history. Authentication sessions continue to be stored in the same SQLite database when it is enabled.
 
 Write-ahead logging, foreign keys, and sensible busy timeouts are enabled automatically via connection pragmas during startup.
 

--- a/src/backend/internal/storage/redis/redis.go
+++ b/src/backend/internal/storage/redis/redis.go
@@ -109,8 +109,8 @@ func (s *Store) GetRecent(ctx context.Context, q storage.QueryOpts) ([]storage.M
 
 	var results []storage.Message
 	sinceTS := int64(0)
-	if q.Since != nil {
-		sinceTS = q.Since.UTC().UnixMilli()
+	if q.SinceTS != nil {
+		sinceTS = q.SinceTS.UTC().UnixMilli()
 	}
 
 	for _, entry := range entries {
@@ -120,12 +120,6 @@ func (s *Store) GetRecent(ctx context.Context, q storage.QueryOpts) ([]storage.M
 			continue
 		}
 		if sinceTS > 0 && msg.Timestamp.UTC().UnixMilli() < sinceTS {
-			continue
-		}
-		if q.Platform != nil && msg.Platform != *q.Platform {
-			continue
-		}
-		if q.Username != nil && msg.Username != *q.Username {
 			continue
 		}
 		results = append(results, msg)

--- a/src/backend/internal/storage/sqlite/sqlite.go
+++ b/src/backend/internal/storage/sqlite/sqlite.go
@@ -181,26 +181,11 @@ func (s *Store) GetRecent(ctx context.Context, q storage.QueryOpts) ([]storage.M
 	}
 
 	query := `SELECT id, ts, username, platform, text, emotes_json, COALESCE(raw_json, '') FROM messages`
-	var conditions []string
 	var args []any
-
-	if q.Since != nil {
-		conditions = append(conditions, "ts >= ?")
-		args = append(args, q.Since.UTC().UnixMilli())
+	if q.SinceTS != nil {
+		query += " WHERE ts >= ?"
+		args = append(args, q.SinceTS.UTC().UnixMilli())
 	}
-	if q.Platform != nil {
-		conditions = append(conditions, "platform = ?")
-		args = append(args, *q.Platform)
-	}
-	if q.Username != nil {
-		conditions = append(conditions, "username = ?")
-		args = append(args, *q.Username)
-	}
-
-	if len(conditions) > 0 {
-		query += " WHERE " + strings.Join(conditions, " AND ")
-	}
-
 	query += " ORDER BY ts DESC"
 	if q.Limit > 0 {
 		query += " LIMIT ?"

--- a/src/backend/internal/storage/storage.go
+++ b/src/backend/internal/storage/storage.go
@@ -27,10 +27,8 @@ type Session struct {
 
 // QueryOpts defines filters for retrieving stored messages.
 type QueryOpts struct {
-	Limit    int
-	Since    *time.Time
-	Platform *string
-	Username *string
+	Limit   int
+	SinceTS *time.Time
 }
 
 // Store describes a backend capable of persisting chat messages and sessions.

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	baseCtx := context.Background()
 
-	storeKind := strings.ToLower(strings.TrimSpace(getEnvOrDefault("ELORA_STORE", "redis")))
+	storeKind := strings.ToLower(strings.TrimSpace(getEnvOrDefault("ELORA_STORE", "sqlite")))
 	var (
 		store       storage.Store
 		redisClient *redis.Client

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -119,6 +119,7 @@ func main() {
 	routes.SetupChatRoutes(r)
 	routes.SetupAuthRoutes(r)
 	routes.SetupSendRoutes(r)
+	routes.SetupMessageRoutes(r)
 
 	// Serve static files from the "public" directory
 	fs := http.FileServer(http.Dir("public"))

--- a/src/backend/routes/messages.go
+++ b/src/backend/routes/messages.go
@@ -41,7 +41,7 @@ func handleGetRecentMessages(w http.ResponseWriter, r *http.Request) {
 
 	messages, err := chatStore.GetRecent(r.Context(), storage.QueryOpts{
 		Limit: limit,
-		Since: since,
+		SinceTS: since,
 	})
 	if err != nil {
 		http.Error(w, "failed to fetch messages", http.StatusInternalServerError)

--- a/src/backend/routes/messages.go
+++ b/src/backend/routes/messages.go
@@ -1,0 +1,124 @@
+package routes
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/hpwn/EloraChat/src/backend/internal/storage"
+)
+
+const (
+	defaultMessagesLimit = 100
+	maxMessagesLimit     = 500
+)
+
+func SetupMessageRoutes(r *mux.Router) {
+	r.HandleFunc("/api/messages", handleGetRecentMessages).Methods(http.MethodGet)
+}
+
+func handleGetRecentMessages(w http.ResponseWriter, r *http.Request) {
+	if chatStore == nil {
+		http.Error(w, "storage not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	limit, err := parseLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	since, err := parseSince(r.URL.Query().Get("since_ts"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	messages, err := chatStore.GetRecent(r.Context(), storage.QueryOpts{
+		Limit: limit,
+		Since: since,
+	})
+	if err != nil {
+		http.Error(w, "failed to fetch messages", http.StatusInternalServerError)
+		return
+	}
+
+	type messageResponse struct {
+		ID         string `json:"id"`
+		Timestamp  string `json:"ts"`
+		Username   string `json:"username"`
+		Platform   string `json:"platform"`
+		Text       string `json:"text"`
+		EmotesJSON string `json:"emotes_json"`
+		RawJSON    string `json:"raw_json"`
+	}
+
+	resp := make([]messageResponse, 0, len(messages))
+	for _, msg := range messages {
+		resp = append(resp, messageResponse{
+			ID:         msg.ID,
+			Timestamp:  msg.Timestamp.UTC().Format(time.RFC3339Nano),
+			Username:   msg.Username,
+			Platform:   msg.Platform,
+			Text:       msg.Text,
+			EmotesJSON: msg.EmotesJSON,
+			RawJSON:    msg.RawJSON,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(resp); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+func parseLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultMessagesLimit, nil
+	}
+
+	limit, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, errors.New("invalid limit")
+	}
+	if limit <= 0 {
+		return 0, errors.New("limit must be positive")
+	}
+	if limit > maxMessagesLimit {
+		limit = maxMessagesLimit
+	}
+	return limit, nil
+}
+
+func parseSince(raw string) (*time.Time, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	if ms, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if ms <= 0 {
+			return nil, errors.New("invalid since_ts")
+		}
+		t := time.UnixMilli(ms).UTC()
+		return &t, nil
+	}
+
+	if ts, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		t := ts.UTC()
+		return &t, nil
+	}
+	if ts, err := time.Parse(time.RFC3339, raw); err == nil {
+		t := ts.UTC()
+		return &t, nil
+	}
+
+	return nil, errors.New("invalid since_ts")
+}

--- a/src/backend/routes/messages_test.go
+++ b/src/backend/routes/messages_test.go
@@ -1,0 +1,191 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/hpwn/EloraChat/src/backend/internal/storage"
+	"github.com/hpwn/EloraChat/src/backend/internal/storage/sqlite"
+)
+
+type recentMessageResponse struct {
+	ID         string `json:"id"`
+	Timestamp  string `json:"ts"`
+	Username   string `json:"username"`
+	Platform   string `json:"platform"`
+	Text       string `json:"text"`
+	EmotesJSON string `json:"emotes_json"`
+	RawJSON    string `json:"raw_json"`
+}
+
+func withSQLiteStore(t *testing.T) func() {
+	t.Helper()
+
+	prevStore := chatStore
+
+	store := sqlite.New(sqlite.Config{Mode: "ephemeral"})
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("sqlite init: %v", err)
+	}
+
+	chatStore = store
+
+	return func() {
+		if err := store.Close(context.Background()); err != nil {
+			t.Errorf("sqlite close: %v", err)
+		}
+		chatStore = prevStore
+	}
+}
+
+func seedRecentMessages(t *testing.T) []storage.Message {
+	t.Helper()
+
+	base := time.Now().UTC().Add(-2 * time.Minute)
+	msgs := []storage.Message{
+		{
+			ID:        "msg-1",
+			Timestamp: base.Add(10 * time.Second),
+			Username:  "user-a",
+			Platform:  "twitch",
+			Text:      "hello",
+		},
+		{
+			ID:        "msg-2",
+			Timestamp: base.Add(20 * time.Second),
+			Username:  "user-b",
+			Platform:  "youtube",
+			Text:      "world",
+		},
+		{
+			ID:        "msg-3",
+			Timestamp: base.Add(30 * time.Second),
+			Username:  "user-c",
+			Platform:  "twitch",
+			Text:      "!!!",
+		},
+	}
+
+	for i := range msgs {
+		// ensure deterministic ordering in store
+		if err := chatStore.InsertMessage(context.Background(), &msgs[i]); err != nil {
+			t.Fatalf("insert message %d: %v", i, err)
+		}
+	}
+
+	return msgs
+}
+
+func newMessagesRouter() *mux.Router {
+	r := mux.NewRouter()
+	SetupMessageRoutes(r)
+	return r
+}
+
+func TestHandleGetRecentMessages_DefaultLimit(t *testing.T) {
+	cleanup := withSQLiteStore(t)
+	defer cleanup()
+
+	msgs := seedRecentMessages(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages", nil)
+	rr := httptest.NewRecorder()
+
+	router := newMessagesRouter()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	var payload []recentMessageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(payload) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(payload))
+	}
+
+	if payload[0].ID != msgs[2].ID {
+		t.Fatalf("expected most recent message id %q, got %q", msgs[2].ID, payload[0].ID)
+	}
+
+	if _, err := time.Parse(time.RFC3339Nano, payload[0].Timestamp); err != nil {
+		t.Fatalf("timestamp is not RFC3339: %v", err)
+	}
+}
+
+func TestHandleGetRecentMessages_SinceAndLimit(t *testing.T) {
+	cleanup := withSQLiteStore(t)
+	defer cleanup()
+
+	msgs := seedRecentMessages(t)
+
+	since := msgs[1].Timestamp.UTC().Format(time.RFC3339Nano)
+	rawURL := fmt.Sprintf("/api/messages?since_ts=%s&limit=1", url.QueryEscape(since))
+
+	req := httptest.NewRequest(http.MethodGet, rawURL, nil)
+	rr := httptest.NewRecorder()
+
+	router := newMessagesRouter()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	var payload []recentMessageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(payload) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(payload))
+	}
+
+	if payload[0].ID != msgs[2].ID {
+		t.Fatalf("expected message id %q, got %q", msgs[2].ID, payload[0].ID)
+	}
+
+	if _, err := time.Parse(time.RFC3339Nano, payload[0].Timestamp); err != nil {
+		t.Fatalf("timestamp is not RFC3339: %v", err)
+	}
+}
+
+func TestHandleGetRecentMessages_SinceUnixMillis(t *testing.T) {
+	cleanup := withSQLiteStore(t)
+	defer cleanup()
+
+	msgs := seedRecentMessages(t)
+
+	since := msgs[0].Timestamp.UTC().UnixMilli()
+	rawURL := fmt.Sprintf("/api/messages?since_ts=%d", since)
+
+	req := httptest.NewRequest(http.MethodGet, rawURL, nil)
+	rr := httptest.NewRecorder()
+
+	router := newMessagesRouter()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	var payload []recentMessageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(payload) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(payload))
+	}
+}


### PR DESCRIPTION
Adds /api/messages with limit/since_ts filters, switches chat history reads to SQLite, and includes unit tests.  
Verified locally with Docker, seeded DB, and jq checks:
- ✅ default returns 100 messages
- ✅ limit=10 works
- ✅ since_ts filter returns expected 50 rows (msg-0151..msg-0200)
- ✅ timestamps are RFC3339 UTC
