### PR TITLE
feat(api/messages): cursor pagination (before_ts), envelope response, and index (PR5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ curl "http://localhost:8080/api/messages?since_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 elora-chat is easy to use. Simply start the server and connect your streaming platforms. The chat will be unified and available in your dashboard for a seamless streaming experience.
 
+### Fetch recent messages with pagination
+
+```bash
+# Fetch the newest messages (default limit = 50)
+curl -s "http://localhost:8080/api/messages" | jq "."
+
+# Request a smaller page size
+curl -s "http://localhost:8080/api/messages?limit=25" | jq "."
+
+# Walk backwards using the returned next_before_ts cursor
+resp=$(curl -s "http://localhost:8080/api/messages?limit=25")
+next=$(echo "$resp" | jq -r ".next_before_ts // empty")
+curl -s "http://localhost:8080/api/messages?limit=25&before_ts=$next" | jq "."
+```
+
 ## Contributing 🧑🏼‍💻
 
 If you have ideas for improvement or want to contribute to elora-chat, feel free to create a pull request or contact Hayden for collaboration.

--- a/src/backend/internal/storage/sqlite/migrations/0003_add_idx_messages_ts_id.sql
+++ b/src/backend/internal/storage/sqlite/migrations/0003_add_idx_messages_ts_id.sql
@@ -1,0 +1,2 @@
+-- 0003_add_idx_messages_ts_id.sql
+CREATE INDEX IF NOT EXISTS idx_messages_ts_id ON messages(ts DESC, id DESC);

--- a/src/backend/internal/storage/storage.go
+++ b/src/backend/internal/storage/storage.go
@@ -27,8 +27,9 @@ type Session struct {
 
 // QueryOpts defines filters for retrieving stored messages.
 type QueryOpts struct {
-	Limit   int
-	SinceTS *time.Time
+	Limit    int
+	SinceTS  *time.Time // return messages with Timestamp >= SinceTS (newer-than)
+	BeforeTS *time.Time // return messages with Timestamp < BeforeTS (older-than)
 }
 
 // Store describes a backend capable of persisting chat messages and sessions.


### PR DESCRIPTION
## Summary
- Add `before_ts` cursor to `GET /api/messages` with paginated envelope: `{ items: [...], next_before_ts }`.
- Validate mutually-exclusive `since_ts` vs `before_ts`; return 400 for conflicts.
- Order by `ts DESC, id DESC`; add SQLite index to match ordering.
- Update storage interface and both SQLite/Redis implementations to honor new `QueryOpts`.
- Expand tests for pagination, cursor conflicts, and envelope schema.
- README: usage examples for cursor-based fetching.

## Testing
- `cd src/backend && go build ./... && go test ./...`
- Docker (SQLite persistent) with seeded data:
  - `curl -sS 'http://localhost:8080/api/messages?limit=25'`
  - Follow `next_before_ts` across pages.
  - Verify 400 on `?since_ts=...&before_ts=...`.
