### PR TITLE
feat(api): export (NDJSON/CSV) + purge + Store.PurgeBefore

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,33 @@ curl "http://localhost:8080/api/messages?limit=20"
 curl "http://localhost:8080/api/messages?since_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)&limit=50"
 ```
 
+### Export & Purge
+
+Admins (or curious humans) can export chat history and purge old rows without touching the database directly.
+
+Export messages (default format is NDJSON):
+
+```bash
+# Stream the latest 1,000 messages as NDJSON
+curl -s "http://localhost:8080/api/messages/export?limit=1000" > messages.ndjson
+
+# CSV export
+curl -s "http://localhost:8080/api/messages/export?format=csv&limit=500" > messages.csv
+
+# Time filters (Unix epoch millis); since_ts and before_ts are mutually exclusive
+since=$(date -u +%s%3N)
+curl -s "http://localhost:8080/api/messages/export?since_ts=$since&limit=200" > recent.ndjson
+```
+
+Purge old messages (timestamps are Unix epoch millis, rows strictly older than the cutoff are removed):
+
+```bash
+cutoff=$(date -u -d '30 days ago' +%s%3N)
+curl -s -X POST http://localhost:8080/api/messages/purge \
+  -H "Content-Type: application/json" \
+  -d "{\"before_ts\":$cutoff}"
+```
+
 ## Usage ⌨️
 
 elora-chat is easy to use. Simply start the server and connect your streaming platforms. The chat will be unified and available in your dashboard for a seamless streaming experience.

--- a/src/backend/internal/storage/storage.go
+++ b/src/backend/internal/storage/storage.go
@@ -37,6 +37,8 @@ type Store interface {
 	Init(ctx context.Context) error
 	InsertMessage(ctx context.Context, m *Message) error
 	GetRecent(ctx context.Context, q QueryOpts) ([]Message, error)
+	// PurgeBefore deletes messages with timestamps strictly before the cutoff.
+	PurgeBefore(ctx context.Context, cutoff time.Time) (int, error)
 	PurgeAll(ctx context.Context) error
 	GetSession(ctx context.Context, token string) (*Session, error)
 	UpsertSession(ctx context.Context, s *Session) error

--- a/src/backend/routes/messages.go
+++ b/src/backend/routes/messages.go
@@ -35,6 +35,8 @@ type messagesEnvelope struct {
 
 func SetupMessageRoutes(r *mux.Router) {
 	r.HandleFunc("/api/messages", handleGetRecentMessages).Methods(http.MethodGet)
+	r.HandleFunc("/api/messages/export", handleExportMessages).Methods(http.MethodGet)
+	r.HandleFunc("/api/messages/purge", handlePurgeMessages).Methods(http.MethodPost)
 }
 
 func handleGetRecentMessages(w http.ResponseWriter, r *http.Request) {

--- a/src/backend/routes/messages_export.go
+++ b/src/backend/routes/messages_export.go
@@ -1,0 +1,172 @@
+package routes
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hpwn/EloraChat/src/backend/internal/storage"
+)
+
+const (
+	defaultExportLimit = 1000
+	maxExportLimit     = 100000
+)
+
+type exportRecord struct {
+	ID         string `json:"id"`
+	Timestamp  string `json:"ts"`
+	Username   string `json:"username"`
+	Platform   string `json:"platform"`
+	Text       string `json:"text"`
+	EmotesJSON string `json:"emotes_json"`
+	RawJSON    string `json:"raw_json"`
+}
+
+func parseExportLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultExportLimit, nil
+	}
+
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit <= 0 {
+		return 0, errors.New("invalid limit")
+	}
+	if limit > maxExportLimit {
+		limit = maxExportLimit
+	}
+	return limit, nil
+}
+
+func handleExportMessages(w http.ResponseWriter, r *http.Request) {
+	if chatStore == nil {
+		http.Error(w, "storage not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "ndjson"
+	}
+	if format != "ndjson" && format != "csv" {
+		http.Error(w, "unsupported format", http.StatusBadRequest)
+		return
+	}
+
+	limit, err := parseExportLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	since, err := parseSince(r.URL.Query().Get("since_ts"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	before, err := parseCursor(r.URL.Query().Get("before_ts"), "before_ts")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if since != nil && before != nil {
+		http.Error(w, "since_ts and before_ts are mutually exclusive", http.StatusBadRequest)
+		return
+	}
+
+	messages, err := chatStore.GetRecent(r.Context(), storage.QueryOpts{
+		Limit:    limit,
+		SinceTS:  since,
+		BeforeTS: before,
+	})
+	if err != nil {
+		http.Error(w, "failed to fetch messages", http.StatusInternalServerError)
+		return
+	}
+
+	switch format {
+	case "ndjson":
+		w.Header().Set("Content-Type", "application/x-ndjson; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		for _, msg := range messages {
+			record := exportRecord{
+				ID:         msg.ID,
+				Timestamp:  msg.Timestamp.UTC().Format(time.RFC3339Nano),
+				Username:   msg.Username,
+				Platform:   msg.Platform,
+				Text:       msg.Text,
+				EmotesJSON: msg.EmotesJSON,
+				RawJSON:    msg.RawJSON,
+			}
+			if err := enc.Encode(record); err != nil {
+				return
+			}
+		}
+	case "csv":
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		writer := csv.NewWriter(w)
+		if err := writer.Write([]string{"id", "ts", "username", "platform", "text", "emotes_json", "raw_json"}); err != nil {
+			return
+		}
+		for _, msg := range messages {
+			row := []string{
+				msg.ID,
+				msg.Timestamp.UTC().Format(time.RFC3339Nano),
+				msg.Username,
+				msg.Platform,
+				msg.Text,
+				msg.EmotesJSON,
+				msg.RawJSON,
+			}
+			if err := writer.Write(row); err != nil {
+				return
+			}
+		}
+		writer.Flush()
+		if err := writer.Error(); err != nil {
+			return
+		}
+	}
+}
+
+func handlePurgeMessages(w http.ResponseWriter, r *http.Request) {
+	if chatStore == nil {
+		http.Error(w, "storage not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	var payload struct {
+		BeforeTS int64 `json:"before_ts"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if payload.BeforeTS <= 0 {
+		http.Error(w, "before_ts required", http.StatusBadRequest)
+		return
+	}
+
+	cutoff := time.UnixMilli(payload.BeforeTS).UTC()
+	deleted, err := chatStore.PurgeBefore(r.Context(), cutoff)
+	if err != nil {
+		http.Error(w, "failed to purge", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	resp := struct {
+		Deleted int `json:"deleted"`
+	}{Deleted: deleted}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(resp); err != nil {
+		return
+	}
+}


### PR DESCRIPTION
## Summary
- Added `Store.PurgeBefore(ctx, ts)` with SQLite implementation + tests.
- New HTTP endpoints:
  - `GET /api/messages/export` → NDJSON (default) or CSV via `?format=csv`
  - `POST /api/messages/purge` → deletes rows older than `before_ts` (ms epoch)
- Validations: `since_ts` and `before_ts` are mutually exclusive (400).
- Docs & route tests for export (NDJSON/CSV), conflicts, and purge.

## Testing
- `cd src/backend && go build ./... && go test ./...` passes.
- Verified export streams newest-first, CSV header present, `since_ts` filtering OK.
- Purge removes rows older than cutoff and returns `{ "deleted": N }`.
