### PR TITLE
feat(frontend): Settings-gated Export panel + robust WS parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Admins (or curious humans) can export chat history and purge old rows without to
 
 #### Export via UI
 
-After opening the web app (default http://localhost:8080) you'll see an **Export chat** panel near the top of the page. Use it to:
+After opening the web app (default http://localhost:8080), open **Settings → Show export panel** (gear icon near the input) to reveal the **Export chat** panel near the top of the page. Use it to:
 
 - Choose the output **format** (NDJSON by default, CSV optional)
 - Set a **limit** (defaults to 1,000 messages)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ curl "http://localhost:8080/api/messages?since_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 Admins (or curious humans) can export chat history and purge old rows without touching the database directly.
 
+#### Export via UI
+
+After opening the web app (default http://localhost:8080) you'll see an **Export chat** panel near the top of the page. Use it to:
+
+- Choose the output **format** (NDJSON by default, CSV optional)
+- Set a **limit** (defaults to 1,000 messages)
+- Provide either **since_ts** or **before_ts** in Unix epoch milliseconds — the fields are mutually exclusive
+- Click **Open export** to download immediately, or **Copy curl** to grab a ready-to-run CLI command
+
+#### Export via curl
+
 Export messages (default format is NDJSON):
 
 ```bash

--- a/src/frontend/src/lib/components/Chat.svelte
+++ b/src/frontend/src/lib/components/Chat.svelte
@@ -5,6 +5,7 @@
   import PauseOverlay from './PauseOverlay.svelte';
 
   import { deployedUrl, useDeployedApi } from '$lib/config';
+  import { parseWsMessages } from '$lib/messages';
   import { SvelteSet } from 'svelte/reactivity';
 
   let container: HTMLDivElement;
@@ -124,20 +125,14 @@
     };
 
     ws.onmessage = (event) => {
-      // console.log("Message received: ", event.data);
-      const msg = event.data;
-      if (msg === '__keepalive__') {
+      const incomingMessages = parseWsMessages(event.data);
+      if (incomingMessages.length === 0) {
         return;
       }
 
-      try {
-        const parsedMsg = JSON.parse(msg);
-        messageQueue.push(parsedMsg);
-        if (!processing) {
-          processMessageQueue();
-        }
-      } catch (e) {
-        console.error('Error parsing message:', msg, e);
+      messageQueue.push(...incomingMessages);
+      if (!processing) {
+        processMessageQueue();
       }
     };
 

--- a/src/frontend/src/lib/components/ChatSettings.svelte
+++ b/src/frontend/src/lib/components/ChatSettings.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import SettingsIcon from './icons/SettingsIcon.svelte';
 
-  function toggleChatSettings() {}
+  const dispatch = createEventDispatcher();
+
+  function toggleChatSettings() {
+    dispatch('open-settings');
+  }
 </script>
 
 <button type="button" id="chat-settings-button" title="Chat Settings" on:click={toggleChatSettings}>

--- a/src/frontend/src/lib/components/ExportPanel.svelte
+++ b/src/frontend/src/lib/components/ExportPanel.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let format: 'ndjson' | 'csv' = 'ndjson';
+  let limit = 1000;
+  let since_ts = '';
+  let before_ts = '';
+
+  let exportUrl = '';
+  let curlCmd = '';
+
+  function buildUrl(): string {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+
+    const url = new URL('/api/messages/export', window.location.origin);
+    if (format !== 'ndjson') {
+      url.searchParams.set('format', format);
+    }
+    if (limit > 0) {
+      url.searchParams.set('limit', String(limit));
+    }
+
+    const sinceTrimmed = since_ts.trim();
+    const beforeTrimmed = before_ts.trim();
+    if (sinceTrimmed && beforeTrimmed) {
+      return '';
+    }
+    if (sinceTrimmed) {
+      url.searchParams.set('since_ts', sinceTrimmed);
+    }
+    if (beforeTrimmed) {
+      url.searchParams.set('before_ts', beforeTrimmed);
+    }
+
+    return url.toString();
+  }
+
+  function buildCurl(): string {
+    const url = buildUrl();
+    if (!url) {
+      return '# since_ts and before_ts are mutually exclusive';
+    }
+    const extension = format === 'csv' ? 'csv' : 'ndjson';
+    return `curl -sS "${url}" -o messages.${extension}`;
+  }
+
+  function refreshDerived() {
+    exportUrl = buildUrl();
+    curlCmd = buildCurl();
+  }
+
+  function openExport() {
+    refreshDerived();
+    if (!exportUrl) {
+      alert('Choose only one of since_ts OR before_ts.');
+      return;
+    }
+    window.open(exportUrl, '_blank');
+  }
+
+  function copyCurl() {
+    refreshDerived();
+    if (!curlCmd || curlCmd.startsWith('#')) {
+      alert('Choose only one of since_ts OR before_ts.');
+      return;
+    }
+    navigator.clipboard.writeText(curlCmd).then(
+      () => alert('Copied curl to clipboard'),
+      () => alert('Failed to copy curl')
+    );
+  }
+
+  onMount(() => {
+    refreshDerived();
+  });
+</script>
+
+<div class="export-panel">
+  <h3 class="heading">Export chat</h3>
+
+  <div class="row">
+    <label class="label" for="format">Format</label>
+    <select
+      id="format"
+      class="field"
+      bind:value={format}
+      on:change={refreshDerived}
+    >
+      <option value="ndjson">NDJSON (default)</option>
+      <option value="csv">CSV</option>
+    </select>
+  </div>
+
+  <div class="row">
+    <label class="label" for="limit">Limit</label>
+    <input
+      id="limit"
+      class="field"
+      type="number"
+      min="1"
+      step="1"
+      bind:value={limit}
+      on:input={refreshDerived}
+    />
+  </div>
+
+  <div class="row">
+    <label class="label" for="since">since_ts (ms)</label>
+    <input
+      id="since"
+      class="field"
+      type="text"
+      placeholder="e.g. 1758575000000"
+      bind:value={since_ts}
+      on:input={refreshDerived}
+    />
+  </div>
+
+  <div class="row">
+    <label class="label" for="before">before_ts (ms)</label>
+    <input
+      id="before"
+      class="field"
+      type="text"
+      placeholder="e.g. 1758574000000"
+      bind:value={before_ts}
+      on:input={refreshDerived}
+    />
+  </div>
+
+  <div class="help">
+    Note: <code>since_ts</code> and <code>before_ts</code> are mutually exclusive.
+  </div>
+
+  <div class="actions">
+    <button class="button" type="button" on:click={openExport}>Open export</button>
+    <button class="button secondary" type="button" on:click={copyCurl}>Copy curl</button>
+  </div>
+
+  <div class="preview">
+    <div class="preview-label">Preview URL</div>
+    <div class="preview-value">{exportUrl || '(choose only one of since_ts OR before_ts)'}</div>
+    <div class="preview-label">curl</div>
+    <div class="preview-value">{curlCmd}</div>
+  </div>
+</div>
+
+<style>
+  .export-panel {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 12px;
+    margin: 12px 0;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .heading {
+    margin: 0 0 10px;
+    font-size: 1.05rem;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+
+  .label {
+    font-size: 0.9rem;
+    color: #ddd;
+  }
+
+  .field {
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    padding: 6px 8px;
+    font: inherit;
+    background: rgba(0, 0, 0, 0.35);
+    color: inherit;
+  }
+
+  .help {
+    font-size: 0.8rem;
+    color: #b5b5b5;
+    margin: 6px 0 10px;
+  }
+
+  .actions {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+
+  .button {
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 10px;
+    padding: 6px 10px;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .button.secondary {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .preview-label {
+    margin-top: 8px;
+    font-size: 0.8rem;
+    color: #b5b5b5;
+  }
+
+  .preview-value {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.85rem;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px dashed rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    padding: 6px 8px;
+    overflow: auto;
+  }
+</style>

--- a/src/frontend/src/lib/components/Footer.svelte
+++ b/src/frontend/src/lib/components/Footer.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import SendMessage from './SendMessage.svelte';
   import ChatSettings from './ChatSettings.svelte';
+
+  const dispatch = createEventDispatcher();
+
+  function handleOpenSettings() {
+    dispatch('open-settings');
+  }
 </script>
 
 <footer>
   <SendMessage />
-  <ChatSettings />
+  <ChatSettings on:open-settings={handleOpenSettings} />
 </footer>
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/SettingsModal.svelte
+++ b/src/frontend/src/lib/components/SettingsModal.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { settings } from '$lib/stores/settings';
+
+  let dialog: HTMLDivElement | null = null;
+  export let open = false;
+
+  $: if (open) {
+    tick().then(() => {
+      dialog?.focus();
+    });
+  }
+
+  function close() {
+    open = false;
+  }
+
+  function toggleExportPanel(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    settings.update((current) => ({ ...current, showExportPanel: checked }));
+  }
+
+  function handleOverlayKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      close();
+    }
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (!open) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={handleWindowKeydown} />
+
+{#if open}
+  <div
+    aria-label="Close settings"
+    class="backdrop"
+    on:click={close}
+    on:keydown={handleOverlayKeydown}
+    role="button"
+    tabindex="0"
+  ></div>
+  <div
+    aria-labelledby="settings-modal-title"
+    aria-modal="true"
+    bind:this={dialog}
+    class="modal"
+    role="dialog"
+    tabindex="-1"
+  >
+    <header class="modal__header">
+      <h2 class="modal__title" id="settings-modal-title">Settings</h2>
+      <button class="modal__close" on:click={close} type="button" aria-label="Close settings">
+        ✕
+      </button>
+    </header>
+
+    <div class="modal__content">
+      <label class="toggle">
+        <input
+          checked={$settings.showExportPanel}
+          class="toggle__input"
+          on:change={toggleExportPanel}
+          type="checkbox"
+        />
+        <span class="toggle__label">Show export panel</span>
+      </label>
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 40;
+  }
+
+  .modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(92vw, 520px);
+    border-radius: 1.5rem;
+    background: #111;
+    border: 1px solid #3f3f46;
+    padding: 1.5rem;
+    z-index: 50;
+    color: #f4f4f5;
+  }
+
+  .modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+
+  .modal__title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .modal__close {
+    border: none;
+    border-radius: 0.5rem;
+    background: #1f2937;
+    color: inherit;
+    padding: 0.25rem 0.75rem;
+    cursor: pointer;
+  }
+
+  .modal__close:hover,
+  .modal__close:focus-visible {
+    background: #374151;
+  }
+
+  .modal__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+  }
+
+  .toggle__input {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .toggle__label {
+    user-select: none;
+  }
+</style>

--- a/src/frontend/src/lib/components/index.ts
+++ b/src/frontend/src/lib/components/index.ts
@@ -5,3 +5,4 @@ export { default as ChatMessage } from './ChatMessage.svelte';
 export { default as SendMessage } from './SendMessage.svelte';
 export { default as PauseOverlay } from './PauseOverlay.svelte';
 export { default as ChatSettings } from './ChatSettings.svelte';
+export { default as ExportPanel } from './ExportPanel.svelte';

--- a/src/frontend/src/lib/messages.ts
+++ b/src/frontend/src/lib/messages.ts
@@ -1,0 +1,87 @@
+import type { Message } from '$lib/types/messages';
+
+type MaybeEnvelope<T> = T | { items: T[] } | T[];
+
+const KEEPALIVE_TOKENS = new Set(['__keepalive__', 'ping', 'pong']);
+
+function normalizePayload<T>(payload: MaybeEnvelope<T>): T[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && typeof payload === 'object' && 'items' in payload) {
+    const items = (payload as { items?: unknown }).items;
+    if (Array.isArray(items)) {
+      return items as T[];
+    }
+  }
+
+  if (payload && typeof payload === 'object') {
+    return [payload as T];
+  }
+
+  return [];
+}
+
+function coerceMessage(raw: unknown): Message | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const candidate = raw as Record<string, unknown>;
+  const author = typeof candidate.author === 'string' ? candidate.author : 'Unknown';
+  const message = typeof candidate.message === 'string' ? candidate.message : '';
+  const colour = typeof candidate.colour === 'string' ? candidate.colour : '#ffffff';
+  const badges = Array.isArray(candidate.badges) ? (candidate.badges as Message['badges']) : [];
+  const fragments = Array.isArray(candidate.fragments)
+    ? (candidate.fragments as Message['fragments'])
+    : [];
+  const emotes = Array.isArray(candidate.emotes) ? (candidate.emotes as Message['emotes']) : [];
+  const source = candidate.source === 'Twitch' || candidate.source === 'YouTube' ? candidate.source : 'YouTube';
+
+  return {
+    author,
+    badges,
+    colour,
+    message,
+    fragments,
+    emotes,
+    source
+  } as Message;
+}
+
+export function parseWsMessages(eventData: unknown): Message[] {
+  if (typeof eventData === 'string') {
+    if (KEEPALIVE_TOKENS.has(eventData)) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(eventData) as MaybeEnvelope<unknown>;
+      return normalizePayload(parsed)
+        .map((item) => coerceMessage(item))
+        .filter((item): item is Message => item !== null);
+    } catch (error) {
+      console.warn('Unable to parse websocket payload', error, eventData);
+      return [];
+    }
+  }
+
+  if (eventData instanceof ArrayBuffer) {
+    try {
+      const decoded = new TextDecoder().decode(eventData);
+      return parseWsMessages(decoded);
+    } catch (error) {
+      console.warn('Unable to decode websocket ArrayBuffer payload', error);
+      return [];
+    }
+  }
+
+  if (KEEPALIVE_TOKENS.has(String(eventData))) {
+    return [];
+  }
+
+  return normalizePayload(eventData as MaybeEnvelope<unknown>)
+    .map((item) => coerceMessage(item))
+    .filter((item): item is Message => item !== null);
+}

--- a/src/frontend/src/lib/stores/settings.ts
+++ b/src/frontend/src/lib/stores/settings.ts
@@ -1,0 +1,48 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+export type Settings = {
+  showExportPanel: boolean;
+};
+
+const KEY = 'elora.settings.v1';
+const DEFAULT_SETTINGS: Settings = { showExportPanel: false };
+
+function loadSettings(): Settings {
+  if (!browser) {
+    return DEFAULT_SETTINGS;
+  }
+
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return DEFAULT_SETTINGS;
+    }
+
+    return {
+      showExportPanel: !!(parsed as Partial<Settings>).showExportPanel
+    };
+  } catch (error) {
+    console.warn('Failed to load settings from storage', error);
+    return DEFAULT_SETTINGS;
+  }
+}
+
+export const settings = writable<Settings>(DEFAULT_SETTINGS);
+
+if (browser) {
+  settings.set(loadSettings());
+
+  settings.subscribe((value) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(value));
+    } catch (error) {
+      console.warn('Failed to persist settings', error);
+    }
+  });
+}

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { checkLoginStatus } from '$lib/api/auth.svelte';
-  import { Chat, Header, Footer } from '$lib/components';
+  import { Chat, Header, Footer, ExportPanel } from '$lib/components';
   import { onMount } from 'svelte';
 
   const urlParams = new URLSearchParams(window.location.search);
@@ -25,6 +25,9 @@
 
 {#if !isPopout}
   <Header />
+  <div class="export-wrapper">
+    <ExportPanel />
+  </div>
 {/if}
 <Chat />
 <Footer />
@@ -171,5 +174,11 @@
     50% {
       transform: translateX(0.5rem) translateY(0.25rem);
     }
+  }
+
+  .export-wrapper {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 0 16px;
   }
 </style>

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -1,10 +1,13 @@
 <script>
   import { checkLoginStatus } from '$lib/api/auth.svelte';
   import { Chat, Header, Footer, ExportPanel } from '$lib/components';
+  import SettingsModal from '$lib/components/SettingsModal.svelte';
+  import { settings } from '$lib/stores/settings';
   import { onMount } from 'svelte';
 
   const urlParams = new URLSearchParams(window.location.search);
   let isPopout = urlParams.has('popout');
+  let settingsOpen = false;
 
   onMount(() => {
     checkLoginStatus();
@@ -25,12 +28,16 @@
 
 {#if !isPopout}
   <Header />
-  <div class="export-wrapper">
-    <ExportPanel />
-  </div>
+  {#if $settings.showExportPanel}
+    <div class="export-wrapper">
+      <ExportPanel />
+    </div>
+  {/if}
 {/if}
 <Chat />
-<Footer />
+<Footer on:open-settings={() => (settingsOpen = true)} />
+
+<SettingsModal bind:open={settingsOpen} />
 
 <style lang="scss">
   :global(:root) {


### PR DESCRIPTION
**What**
- Adds Settings modal with persisted “Show export panel” toggle; panel hidden by default.
- Gear button opens Settings; export panel visibility driven by stored preference.
- Hardens WebSocket parsing (arrays, singletons, envelopes, keepalives) to prevent render crashes.
- README notes the Settings toggle to reveal export UI.

**Why**
- Keeps main UI clean while still exposing export tools when desired.
- Fix for prior runtime `Symbol.iterator` errors causing blank chat.

**How to test**
- Fresh profile: export panel hidden.
- Settings (gear) → enable “Show export panel”; persists across reloads.
- Send chat: renders; no console errors.
- Export NDJSON/CSV works; since_ts/before_ts mutually exclusive (UI + server 400).
- /api/messages pagination intact (`ts DESC, id DESC`, `next_before_ts`).

**Notes**
- Backend unchanged in this PR (UI only).