### PR TITLE
Export panel: use buildApiUrl for export URLs (PR8a)

### DIFF
--- a/src/frontend/src/lib/components/ExportPanel.svelte
+++ b/src/frontend/src/lib/components/ExportPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { buildApiUrl } from '$lib/utils';
   import { onMount } from 'svelte';
 
   let format: 'ndjson' | 'csv' = 'ndjson';
@@ -14,7 +15,7 @@
       return '';
     }
 
-    const url = new URL('/api/messages/export', window.location.origin);
+    const url = new URL(buildApiUrl('/api/messages/export'), window.location.origin);
     if (format !== 'ndjson') {
       url.searchParams.set('format', format);
     }


### PR DESCRIPTION
Summary

- Updated Export panel to construct URLs via shared buildApiUrl so deployments respect configured API base (same behavior as the rest of the app).

Testing

- Backend: go build/test ✅
- Frontend: npm ci && npm run build ✅
- Manual: UI on :8080 + API on :8080 works; cross-origin static UI requires VITE_DEPLOYED_API_URL at build time, confirmed helper wiring.
