### PR TITLE
DB tailer: live WS from SQLite (gnasty integration)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,14 @@ ELORA_DB_BUSY_TIMEOUT_MS=5000
 # Extra pragmas applied on connection (comma-separated key=value pairs)
 # mmap_size speeds up large queries, cache_size negative = pages in KB, temp_store=MEMORY
 ELORA_DB_PRAGMAS_EXTRA=mmap_size=268435456,cache_size=-100000,temp_store=MEMORY
+
+# ---------------------------
+# SQLite DB tailer (optional)
+# ---------------------------
+
+# Enable polling the SQLite DB for externally ingested chat rows (e.g., gnasty-chat)
+ELORA_DB_TAIL_ENABLED=false
+# Poll interval in milliseconds
+ELORA_DB_TAIL_INTERVAL_MS=200
+# Maximum number of rows fetched per poll
+ELORA_DB_TAIL_BATCH=500

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ SQLite is the only storage backend. All chat history and authentication sessions
 
 Write-ahead logging, foreign keys, and sensible busy timeouts are enabled automatically via connection pragmas during startup.
 
+### Live WS from external ingest (DB tailer)
+If another process such as **gnasty-chat** writes directly to the same SQLite file, Elora can broadcast those rows live without
+running the Python fetcher. Set the tailer env vars alongside your persistent database configuration:
+
+```
+ELORA_DB_MODE=persistent
+ELORA_DB_PATH=/data/elora.db
+ELORA_DB_TAIL_ENABLED=true
+ELORA_DB_TAIL_INTERVAL_MS=200
+ELORA_DB_TAIL_BATCH=500
+```
+
+Run gnasty so it ingests into `/data/elora.db` (for example via a shared Docker volume) and start Elora with the same volume
+mounted to enable real-time updates.
+
 ### HTTP: recent messages
 
 Recent chat history can be fetched directly from the backend with `GET /api/messages`.

--- a/src/backend/internal/storage/sqlite/sqlite.go
+++ b/src/backend/internal/storage/sqlite/sqlite.go
@@ -232,6 +232,68 @@ func (s *Store) GetRecent(ctx context.Context, q storage.QueryOpts) ([]storage.M
 	return results, nil
 }
 
+// TailHead returns the maximum timestamp and rowid currently present in the messages table.
+func (s *Store) TailHead(ctx context.Context) (storage.TailPosition, error) {
+	if s.db == nil {
+		return storage.TailPosition{}, errors.New("sqlite: store not initialized")
+	}
+
+	row := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(ts), 0), COALESCE(MAX(rowid), 0) FROM messages`)
+
+	var pos storage.TailPosition
+	if err := row.Scan(&pos.TS, &pos.RowID); err != nil {
+		return storage.TailPosition{}, fmt.Errorf("sqlite: tail head: %w", err)
+	}
+
+	return pos, nil
+}
+
+// TailNext returns up to limit messages strictly after the provided position ordered by timestamp then rowid.
+func (s *Store) TailNext(ctx context.Context, after storage.TailPosition, limit int) ([]storage.Message, storage.TailPosition, error) {
+	if s.db == nil {
+		return nil, after, errors.New("sqlite: store not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 500
+	}
+
+	query := `SELECT id, ts, username, platform, text, emotes_json, COALESCE(raw_json, ''), rowid
+FROM messages
+WHERE ts > ? OR (ts = ? AND rowid > ?)
+ORDER BY ts ASC, rowid ASC
+LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, query, after.TS, after.TS, after.RowID, limit)
+	if err != nil {
+		return nil, after, fmt.Errorf("sqlite: tail next query: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]storage.Message, 0, limit)
+	last := after
+
+	for rows.Next() {
+		var (
+			msg   storage.Message
+			ts    int64
+			rowID int64
+		)
+		if err := rows.Scan(&msg.ID, &ts, &msg.Username, &msg.Platform, &msg.Text, &msg.EmotesJSON, &msg.RawJSON, &rowID); err != nil {
+			return nil, after, fmt.Errorf("sqlite: tail next scan: %w", err)
+		}
+		msg.Timestamp = time.UnixMilli(ts).UTC()
+		results = append(results, msg)
+		last = storage.TailPosition{TS: ts, RowID: rowID}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, after, fmt.Errorf("sqlite: tail next rows: %w", err)
+	}
+
+	return results, last, nil
+}
+
 // PurgeBefore deletes chat messages with timestamps strictly less than the provided cutoff.
 func (s *Store) PurgeBefore(ctx context.Context, cutoff time.Time) (int, error) {
 	if s.db == nil {

--- a/src/backend/internal/storage/storage.go
+++ b/src/backend/internal/storage/storage.go
@@ -16,6 +16,12 @@ type Message struct {
 	RawJSON    string
 }
 
+// TailPosition represents a cursor for iterating over messages in timestamp/rowid order.
+type TailPosition struct {
+	TS    int64
+	RowID int64
+}
+
 // Session represents auth/session state persisted by the backend.
 type Session struct {
 	Token       string

--- a/src/backend/internal/tailer/dbtailer.go
+++ b/src/backend/internal/tailer/dbtailer.go
@@ -1,0 +1,147 @@
+package tailer
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/hpwn/EloraChat/src/backend/internal/storage"
+	"github.com/hpwn/EloraChat/src/backend/routes"
+)
+
+// Position represents the tail cursor for iterating over messages.
+// It aliases storage.TailPosition to avoid introducing an import cycle.
+type Position = storage.TailPosition
+
+// Store describes the subset of storage capabilities required by the tailer.
+type Store interface {
+	TailHead(ctx context.Context) (storage.TailPosition, error)
+	TailNext(ctx context.Context, after storage.TailPosition, limit int) ([]storage.Message, storage.TailPosition, error)
+}
+
+// Config controls how the database tailer operates.
+type Config struct {
+	Enabled  bool
+	Interval time.Duration
+	Batch    int
+}
+
+// Runner periodically polls the backing store for new messages and broadcasts them.
+type Runner struct {
+	cfg   Config
+	store Store
+
+	mu   sync.Mutex
+	seen map[string]struct{}
+	last storage.TailPosition
+
+	cancel context.CancelFunc
+}
+
+// New creates a new Runner with the provided configuration and store.
+func New(cfg Config, store Store) *Runner {
+	return &Runner{
+		cfg:   cfg,
+		store: store,
+		seen:  make(map[string]struct{}, 1024),
+	}
+}
+
+// Start begins the background polling loop if enabled.
+func (r *Runner) Start(ctx context.Context) error {
+	if !r.cfg.Enabled {
+		return nil
+	}
+	if r.store == nil {
+		return nil
+	}
+
+	head, err := r.store.TailHead(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("dbtailer: enabled interval=%s batch=%d start_pos ts=%d rowid=%d",
+		r.cfg.Interval, r.cfg.Batch, head.TS, head.RowID)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.last = head
+
+	go r.loop(runCtx)
+
+	return nil
+}
+
+// Stop terminates the background polling loop if it is running.
+func (r *Runner) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+}
+
+func (r *Runner) loop(ctx context.Context) {
+	interval := r.cfg.Interval
+	if interval <= 0 {
+		interval = 200 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.tick(ctx)
+		}
+	}
+}
+
+func (r *Runner) tick(ctx context.Context) {
+	batchSize := r.cfg.Batch
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+
+	msgs, last, err := r.store.TailNext(ctx, r.last, batchSize)
+	if err != nil {
+		log.Printf("dbtailer: error: %v", err)
+		return
+	}
+
+	r.last = last
+	if len(msgs) == 0 {
+		return
+	}
+
+	toBroadcast := make([]storage.Message, 0, len(msgs))
+
+	r.mu.Lock()
+	for _, msg := range msgs {
+		if msg.ID == "" {
+			continue
+		}
+		if _, ok := r.seen[msg.ID]; ok {
+			continue
+		}
+		r.seen[msg.ID] = struct{}{}
+		toBroadcast = append(toBroadcast, msg)
+	}
+	if len(r.seen) > 200_000 {
+		r.seen = make(map[string]struct{}, 1024)
+	}
+	r.mu.Unlock()
+
+	if len(toBroadcast) == 0 {
+		return
+	}
+
+	for _, msg := range toBroadcast {
+		routes.BroadcastFromTailer(msg)
+	}
+
+	log.Printf("dbtailer: published n=%d new messages; last_pos ts=%d rowid=%d",
+		len(toBroadcast), r.last.TS, r.last.RowID)
+}

--- a/src/backend/routes/chat.go
+++ b/src/backend/routes/chat.go
@@ -295,6 +295,29 @@ func broadcastChatMessage(msg []byte) {
 	}
 }
 
+// BroadcastFromTailer enqueues a stored message onto the WebSocket broadcast loop.
+func BroadcastFromTailer(m storage.Message) {
+	payload := []byte(m.RawJSON)
+	if len(payload) == 0 {
+		fallback := Message{
+			Author:  m.Username,
+			Message: m.Text,
+			Source:  m.Platform,
+			Tokens:  []Token{},
+			Emotes:  []Emote{},
+			Badges:  []Badge{},
+		}
+		data, err := json.Marshal(fallback)
+		if err != nil {
+			log.Printf("dbtailer: failed to marshal fallback message: %v", err)
+			return
+		}
+		payload = data
+	}
+
+	broadcastChatMessage(payload)
+}
+
 func addSubscriber() chan []byte {
 	ch := make(chan []byte, 64)
 	subscribersMu.Lock()


### PR DESCRIPTION
**SQLite DB tailer (poll & broadcast) for external ingest**

### Summary
- Adds a configurable DB tailer that reads new rows from SQLite and publishes through the existing WebSocket hub.
- Controlled by env flags (all default-off):
  - `ELORA_DB_TAIL_ENABLED=false`
  - `ELORA_DB_TAIL_INTERVAL_MS=200`
  - `ELORA_DB_TAIL_BATCH=500`
- Extends storage with a tail cursor and ordered queries (by `ts`, then `rowid`) to fetch batches.
- Minimal shim in routes to broadcast via the current hub path (no UI changes).
- Docs: `.env.example` and README updated with a short “run with gnasty-chat” note.

### Rationale
When ingest is handled externally (e.g., `gnasty-chat` writing into the same SQLite file), the app can still live-update the UI without running a local ingester.

### Notes
- No behavior change unless `ELORA_DB_TAIL_ENABLED=true`.
- Tailer keeps a small in-memory dedupe and logs progress/last position.
