### PR TITLE
feat(chat): reload third-party emotes on twitch/youtube source changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ Notes:
 - For troubleshooting seed failures, prefer `curl -i` (instead of `-fsS`) to keep response status/body visible.
 - `devctl ws` runs websocat + filter directly and does not rely on `make ws*`.
 
+### Docker Compose plugin troubleshooting
+
+If `docker compose ps` crashes (for example with a compose-go/jsonschema segfault) during local development:
+
+1. Verify service status via Docker Engine directly:
+   ```bash
+   docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -E "elora|gnasty"
+   ```
+2. Verify app readiness independently of compose status output:
+   ```bash
+   make health
+   ```
+3. Continue logs/build/restart with the existing `devctl` commands while upgrading Docker Engine/Compose plugin on the host.
+
 All of the commands read configuration from `.env`, so update that file (or export overrides) before running them.
 
 ### Which mode am I in?

--- a/scripts/fix-docker-compose-ubuntu.sh
+++ b/scripts/fix-docker-compose-ubuntu.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+COMPOSE_FILES=(-f "${ROOT_DIR}/docker-compose.yml" -f "${ROOT_DIR}/docker-compose.dev.yml")
+
+log() {
+  printf '[compose-fix] %s\n' "$*"
+}
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  log "This script targets Ubuntu/Linux hosts only."
+  exit 1
+fi
+
+if ! command -v sudo >/dev/null 2>&1; then
+  log "sudo is required."
+  exit 1
+fi
+
+log "Collecting pre-change diagnostics"
+docker --version | tee /tmp/elora-docker-version.before.log
+docker compose version | tee /tmp/elora-docker-compose-version.before.log
+which docker | tee /tmp/elora-which-docker.before.log
+docker info | sed -n '1,60p' | tee /tmp/elora-docker-info.before.log || true
+docker compose "${COMPOSE_FILES[@]}" config >/tmp/elora-compose-config.before.yaml
+if ! docker compose "${COMPOSE_FILES[@]}" ps >/tmp/elora-compose-ps.before.out 2>/tmp/elora-compose-ps.before.log; then
+  log "compose ps failed before upgrade (captured at /tmp/elora-compose-ps.before.log)"
+fi
+
+log "Removing Docker Desktop package if present"
+sudo apt-get remove -y docker-desktop || true
+
+log "Removing conflicting distro packages if present"
+for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do
+  sudo apt-get remove -y "$pkg" || true
+done
+
+log "Installing Docker apt prerequisites"
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+if [[ -f /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+else
+  log "/etc/os-release missing; cannot determine Ubuntu codename"
+  exit 1
+fi
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+log "Installing Docker Engine + Compose plugin"
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+log "Restarting and enabling docker daemon"
+sudo systemctl enable docker
+sudo systemctl restart docker
+
+if ! groups "$USER" | grep -q '\bdocker\b'; then
+  log "Adding ${USER} to docker group"
+  sudo usermod -aG docker "$USER"
+  log "Open a new shell (or run: newgrp docker) before next docker command."
+fi
+
+log "Collecting post-change diagnostics"
+docker --version | tee /tmp/elora-docker-version.after.log
+docker compose version | tee /tmp/elora-docker-compose-version.after.log
+docker compose "${COMPOSE_FILES[@]}" config >/tmp/elora-compose-config.after.yaml
+docker compose "${COMPOSE_FILES[@]}" ps >/tmp/elora-compose-ps.after.out 2>/tmp/elora-compose-ps.after.log
+docker compose "${COMPOSE_FILES[@]}" logs --tail=50 elora-chat >/tmp/elora-compose-logs.after.log 2>&1 || true
+
+log "Re-running elora workflow"
+bash "${ROOT_DIR}/scripts/devctl.sh" build --dev --app all
+bash "${ROOT_DIR}/scripts/devctl.sh" restart --dev
+make -C "${ROOT_DIR}" health
+bash "${ROOT_DIR}/scripts/devctl.sh" test --app all
+(
+  cd "${ROOT_DIR}/src/backend"
+  go test ./routes
+  go test ./...
+)
+
+log "Done. Diagnostics in /tmp/elora-*.{before,after}.*"

--- a/src/backend/routes/chat.go
+++ b/src/backend/routes/chat.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/hpwn/EloraChat/src/backend/internal/authutil"
+	"github.com/hpwn/EloraChat/src/backend/internal/runtimeconfig"
 	"github.com/hpwn/EloraChat/src/backend/internal/storage"
 	"github.com/hpwn/EloraChat/src/backend/internal/tokenfile"
 	"github.com/hpwn/EloraChat/src/backend/internal/ws"
@@ -85,7 +86,11 @@ var (
 var (
 	twitchHelixBaseURL    = "https://api.twitch.tv/helix"
 	twitchOAuthTokenURL   = "https://id.twitch.tv/oauth2/token"
+	youtubeDataAPIBaseURL = "https://www.googleapis.com/youtube/v3"
 	twitchBadgeHTTPClient = &http.Client{
+		Timeout: 3 * time.Second,
+	}
+	youtubeDataHTTPClient = &http.Client{
 		Timeout: 3 * time.Second,
 	}
 	twitchBadgeCacheState = struct {
@@ -117,6 +122,7 @@ var (
 const twitchBadgeCacheTTL = 30 * time.Minute
 
 var tokenizer Tokenizer
+var emoteCacheMu sync.RWMutex
 
 var commandParser CommandParser
 
@@ -174,6 +180,278 @@ type twitchBadgeCacheEntry struct {
 type twitchBroadcasterIDCacheEntry struct {
 	expiresAt     time.Time
 	broadcasterID string
+}
+
+type emodlTargets struct {
+	twitchLogin         string
+	twitchBroadcasterID string
+	youTubeSourceURL    string
+	youTubeChannelID    string
+}
+
+func tokenizerSnapshot() Tokenizer {
+	emoteCacheMu.RLock()
+	defer emoteCacheMu.RUnlock()
+	return tokenizer
+}
+
+func emoteCacheSnapshot() map[string]Emote {
+	emoteCacheMu.RLock()
+	defer emoteCacheMu.RUnlock()
+	if len(tokenizer.EmoteCache) == 0 {
+		return map[string]Emote{}
+	}
+	clone := make(map[string]Emote, len(tokenizer.EmoteCache))
+	for k, v := range tokenizer.EmoteCache {
+		clone[k] = v
+	}
+	return clone
+}
+
+func replaceEmoteCache(cache map[string]Emote) {
+	emoteCacheMu.Lock()
+	defer emoteCacheMu.Unlock()
+	if cache == nil {
+		tokenizer.EmoteCache = map[string]Emote{}
+		return
+	}
+	tokenizer.EmoteCache = cache
+}
+
+func upsertEmoteCache(emotes []Emote) {
+	if len(emotes) == 0 {
+		return
+	}
+	next := emoteCacheSnapshot()
+	for _, e := range emotes {
+		if strings.TrimSpace(e.Name) == "" {
+			continue
+		}
+		next[e.Name] = e
+	}
+	replaceEmoteCache(next)
+}
+
+func normalizeYouTubeChannelIDIdentity(raw string) string {
+	id := strings.TrimSpace(raw)
+	if len(id) != 24 || !strings.HasPrefix(id, "UC") {
+		return ""
+	}
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			continue
+		}
+		return ""
+	}
+	return id
+}
+
+func resolveYouTubeChannelIDBySource(sourceURL string) (string, error) {
+	sourceURL = strings.TrimSpace(sourceURL)
+	if channelID := normalizeYouTubeChannelIDIdentity(sourceURL); channelID != "" {
+		return channelID, nil
+	}
+	normalized := normalizeYouTubeSourceIdentity(sourceURL)
+	if normalized == "" {
+		return "", fmt.Errorf("missing youtube source identity")
+	}
+	if channelID := normalizeYouTubeChannelIDIdentity(normalized); channelID != "" {
+		return channelID, nil
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv("YOUTUBE_API_KEY"))
+	if apiKey == "" {
+		return "", fmt.Errorf("missing youtube data api key (YOUTUBE_API_KEY)")
+	}
+
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return "", err
+	}
+
+	base := strings.TrimRight(strings.TrimSpace(youtubeDataAPIBaseURL), "/")
+	if base == "" {
+		return "", fmt.Errorf("missing youtube data api base url")
+	}
+
+	doRequest := func(endpoint string, query url.Values, out any) error {
+		query.Set("key", apiKey)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+query.Encode(), nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		resp, reqErr := youtubeDataHTTPClient.Do(req)
+		if reqErr != nil {
+			return reqErr
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			return fmt.Errorf("youtube data api http status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+
+	videoID := normalizeYouTubeVideoIDIdentity(parsed.Query().Get("v"))
+	if videoID != "" {
+		var payload struct {
+			Items []struct {
+				Snippet struct {
+					ChannelID string `json:"channelId"`
+				} `json:"snippet"`
+			} `json:"items"`
+		}
+		q := url.Values{}
+		q.Set("part", "snippet")
+		q.Set("id", videoID)
+		if err := doRequest(base+"/videos", q, &payload); err != nil {
+			return "", err
+		}
+		if len(payload.Items) == 0 {
+			return "", fmt.Errorf("youtube videos returned no items for id=%s", videoID)
+		}
+		channelID := normalizeYouTubeChannelIDIdentity(payload.Items[0].Snippet.ChannelID)
+		if channelID == "" {
+			return "", fmt.Errorf("youtube videos returned empty channel id for id=%s", videoID)
+		}
+		return channelID, nil
+	}
+
+	path := strings.Trim(strings.TrimSpace(parsed.Path), "/")
+	if strings.HasPrefix(path, "@") {
+		handle := normalizeYouTubeHandleIdentity(strings.TrimPrefix(strings.Split(path, "/")[0], "@"))
+		if handle == "" {
+			return "", fmt.Errorf("invalid youtube handle in source identity")
+		}
+		var payload struct {
+			Items []struct {
+				ID string `json:"id"`
+			} `json:"items"`
+		}
+		q := url.Values{}
+		q.Set("part", "id")
+		q.Set("forHandle", handle)
+		if err := doRequest(base+"/channels", q, &payload); err != nil {
+			return "", err
+		}
+		if len(payload.Items) == 0 {
+			return "", fmt.Errorf("youtube channels returned no items for handle=%s", handle)
+		}
+		channelID := normalizeYouTubeChannelIDIdentity(payload.Items[0].ID)
+		if channelID == "" {
+			return "", fmt.Errorf("youtube channels returned invalid channel id for handle=%s", handle)
+		}
+		return channelID, nil
+	}
+
+	return "", fmt.Errorf("unsupported youtube source identity")
+}
+
+func buildEmodlOptions(cfg runtimeconfig.Config) (emodl.DownloaderOptions, emodlTargets, error) {
+	targets := emodlTargets{
+		twitchLogin:      normalizeTwitchChannelIdentity(cfg.TwitchChannel),
+		youTubeSourceURL: normalizeYouTubeSourceIdentity(cfg.YouTubeSourceURL),
+	}
+	options := emodl.DownloaderOptions{}
+	var errs []error
+
+	if targets.twitchLogin != "" {
+		id, err := resolveTwitchBroadcasterIDByLogin(targets.twitchLogin)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("twitch broadcaster id resolve failed (channel=%s): %w", targets.twitchLogin, err))
+		} else {
+			targets.twitchBroadcasterID = id
+		}
+	}
+
+	if targets.youTubeSourceURL != "" {
+		id, err := resolveYouTubeChannelIDBySource(targets.youTubeSourceURL)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("youtube channel id resolve failed (source=%s): %w", targets.youTubeSourceURL, err))
+		} else {
+			targets.youTubeChannelID = id
+		}
+	}
+
+	// emodl only accepts one platform-scoped ID per provider in a single load.
+	// Prefer Twitch for the primary scoped pass; YouTube is loaded in a second pass when present.
+	if targets.twitchBroadcasterID != "" {
+		options.SevenTV = &emodl.SevenTVOptions{Platform: "twitch", PlatformID: targets.twitchBroadcasterID}
+		options.BTTV = &emodl.BTTVOptions{Platform: "twitch", PlatformID: targets.twitchBroadcasterID}
+		options.FFZ = &emodl.FFZOptions{Platform: "twitch", PlatformID: targets.twitchBroadcasterID}
+	} else if targets.youTubeChannelID != "" {
+		options.SevenTV = &emodl.SevenTVOptions{Platform: "youtube", PlatformID: targets.youTubeChannelID}
+		options.BTTV = &emodl.BTTVOptions{Platform: "youtube", PlatformID: targets.youTubeChannelID}
+		options.FFZ = &emodl.FFZOptions{Platform: "youtube", PlatformID: targets.youTubeChannelID}
+	}
+
+	if len(errs) > 0 {
+		return options, targets, errors.Join(errs...)
+	}
+	return options, targets, nil
+}
+
+func loadEmoteCache(options emodl.DownloaderOptions) (map[string]Emote, error) {
+	downloader := emodl.NewDownloader(options)
+	emoteCacheTmp, err := downloader.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]Emote, len(emoteCacheTmp))
+	for name, emote := range emoteCacheTmp {
+		next := Emote{
+			ID:        emote.ID,
+			Name:      emote.Name,
+			Locations: emote.Locations,
+			Images:    []Image{},
+		}
+		if len(emote.Images) > 0 {
+			next.Images = append(next.Images, Image(emote.Images[0]))
+		}
+		out[name] = next
+	}
+	return out, nil
+}
+
+func reloadThirdPartyEmotes(cfg runtimeconfig.Config) error {
+	options, targets, buildErr := buildEmodlOptions(cfg)
+	if buildErr != nil {
+		log.Printf("emodl: target resolution warning: %v", buildErr)
+	}
+
+	log.Printf(
+		"emodl: reload targets twitch_login=%q twitch_id=%q youtube_source=%q youtube_channel_id=%q",
+		targets.twitchLogin,
+		targets.twitchBroadcasterID,
+		targets.youTubeSourceURL,
+		targets.youTubeChannelID,
+	)
+
+	next, err := loadEmoteCache(options)
+	if err != nil {
+		return fmt.Errorf("failed to load third party emotes: %w", err)
+	}
+
+	if targets.twitchBroadcasterID != "" && targets.youTubeChannelID != "" {
+		ytOptions := emodl.DownloaderOptions{
+			SevenTV: &emodl.SevenTVOptions{Platform: "youtube", PlatformID: targets.youTubeChannelID},
+			BTTV:    &emodl.BTTVOptions{Platform: "youtube", PlatformID: targets.youTubeChannelID},
+			FFZ:     &emodl.FFZOptions{Platform: "youtube", PlatformID: targets.youTubeChannelID},
+		}
+		ytCache, ytErr := loadEmoteCache(ytOptions)
+		if ytErr != nil {
+			log.Printf("emodl: youtube scoped load warning (channel_id=%s): %v", targets.youTubeChannelID, ytErr)
+		} else {
+			for name, emote := range ytCache {
+				next[name] = emote
+			}
+		}
+	}
+
+	replaceEmoteCache(next)
+	log.Printf("emodl: cache size = %d", len(next))
+	return nil
 }
 
 func (b *Badge) UnmarshalJSON(data []byte) error {
@@ -2260,6 +2538,7 @@ func InitRoutes(store storage.Store) {
 	subscribersMu.Unlock()
 
 	initRuntimeConfig(store)
+	RegisterThirdPartyEmoteReloader(reloadThirdPartyEmotes)
 
 	// Initialize tokenizer
 	tokenizer.TextEffectSep = ':'
@@ -2272,41 +2551,9 @@ func InitRoutes(store storage.Store) {
 		HelpResetDuration: 10 * time.Second,
 	}
 
-	// Load third party emotes
-	downloader := emodl.NewDownloader(emodl.DownloaderOptions{
-		// TEMP: (Dayoman ID hard coded)
-		SevenTV: &emodl.SevenTVOptions{
-			Platform:   "twitch",
-			PlatformID: "39226538",
-		},
-		BTTV: &emodl.BTTVOptions{
-			Platform:   "twitch",
-			PlatformID: "39226538",
-		},
-		FFZ: &emodl.FFZOptions{
-			Platform:   "twitch",
-			PlatformID: "39226538",
-		},
-	})
-	emoteCacheTmp, err := downloader.Load()
-	if err != nil {
-		log.Printf("emodl: Failed to load third party emotes: %v", err)
+	if err := reloadThirdPartyEmotes(currentRuntimeConfig()); err != nil {
+		log.Printf("emodl: failed to load third party emotes: %v", err)
 	}
-	tokenizer.EmoteCache = make(map[string]Emote, len(emoteCacheTmp))
-	for name, emote := range emoteCacheTmp {
-		tokenizer.EmoteCache[name] = Emote{
-			ID:        emote.ID,
-			Name:      emote.Name,
-			Locations: emote.Locations,
-			Images:    []Image{Image(emote.Images[0])},
-		}
-	}
-	log.Printf("emodl: cache size = %d", len(tokenizer.EmoteCache))
-	// DEBUG
-	// log.Println("3P EMOTES SUPPORTED")
-	// for _, e := range tokenizer.EmoteCache {
-	// 	log.Println(e.Name)
-	// }
 }
 
 func maybeExportStoredTwitchToken(store storage.Store) {
@@ -2398,14 +2645,7 @@ func enrichTailerMessage(m storage.Message) Message {
 		msg.Emotes = []Emote{}
 	}
 
-	if tokenizer.EmoteCache == nil {
-		tokenizer.EmoteCache = make(map[string]Emote)
-	}
-	for _, e := range msg.Emotes {
-		if e.Name != "" {
-			tokenizer.EmoteCache[e.Name] = e
-		}
-	}
+	upsertEmoteCache(msg.Emotes)
 
 	if parsed, raw := parseStoredBadges(m.BadgesJSON); parsed != nil || raw != nil {
 		if msg.Badges == nil || len(msg.Badges) == 0 {
@@ -2435,16 +2675,12 @@ func enrichTailerMessage(m storage.Message) Message {
 		if strings.EqualFold(m.Platform, "twitch") && len(msg.Emotes) == 0 {
 			if dec := decodeTwitchSpans(m.Text, m.EmotesJSON); len(dec) > 0 {
 				// Seed tokenizer cache by NAME so tokenization emits emote fragments.
-				for _, e := range dec {
-					if strings.TrimSpace(e.Name) != "" {
-						tokenizer.EmoteCache[e.Name] = e
-					}
-				}
+				upsertEmoteCache(dec)
 				msg.Emotes = append(msg.Emotes, dec...)
 			}
 		}
 
-		for token := range tokenizer.Iter(msg.Message) {
+		for token := range tokenizerSnapshot().Iter(msg.Message) {
 			msg.Tokens = append(msg.Tokens, token)
 		}
 	}

--- a/src/backend/routes/chat_test.go
+++ b/src/backend/routes/chat_test.go
@@ -551,6 +551,96 @@ func TestGetTwitchHelixAppTokenRefreshesNearExpiry(t *testing.T) {
 	}
 }
 
+func TestResolveYouTubeChannelIDBySourceDirectID(t *testing.T) {
+	got, err := resolveYouTubeChannelIDBySource("UCmbSGFM9OU8FwjxZCevr6zw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "UCmbSGFM9OU8FwjxZCevr6zw" {
+		t.Fatalf("unexpected channel id %q", got)
+	}
+}
+
+func TestResolveYouTubeChannelIDBySourceHandle(t *testing.T) {
+	t.Setenv("YOUTUBE_API_KEY", "test-key")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/channels" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("forHandle"); got != "ludwig" {
+			t.Fatalf("expected forHandle=ludwig, got %q", got)
+		}
+		if got := r.URL.Query().Get("key"); got != "test-key" {
+			t.Fatalf("expected key=test-key, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"UCmbSGFM9OU8FwjxZCevr6zw"}]}`))
+	}))
+	defer server.Close()
+
+	oldBase := youtubeDataAPIBaseURL
+	oldClient := youtubeDataHTTPClient
+	youtubeDataAPIBaseURL = server.URL
+	youtubeDataHTTPClient = server.Client()
+	t.Cleanup(func() {
+		youtubeDataAPIBaseURL = oldBase
+		youtubeDataHTTPClient = oldClient
+	})
+
+	got, err := resolveYouTubeChannelIDBySource("https://www.youtube.com/@ludwig/live")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "UCmbSGFM9OU8FwjxZCevr6zw" {
+		t.Fatalf("unexpected channel id %q", got)
+	}
+}
+
+func TestResolveYouTubeChannelIDBySourceVideo(t *testing.T) {
+	t.Setenv("YOUTUBE_API_KEY", "test-key")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/videos" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("id"); got != "abcdefghijk" {
+			t.Fatalf("expected id=abcdefghijk, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"snippet":{"channelId":"UCmbSGFM9OU8FwjxZCevr6zw"}}]}`))
+	}))
+	defer server.Close()
+
+	oldBase := youtubeDataAPIBaseURL
+	oldClient := youtubeDataHTTPClient
+	youtubeDataAPIBaseURL = server.URL
+	youtubeDataHTTPClient = server.Client()
+	t.Cleanup(func() {
+		youtubeDataAPIBaseURL = oldBase
+		youtubeDataHTTPClient = oldClient
+	})
+
+	got, err := resolveYouTubeChannelIDBySource("https://www.youtube.com/watch?v=abcdefghijk")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "UCmbSGFM9OU8FwjxZCevr6zw" {
+		t.Fatalf("unexpected channel id %q", got)
+	}
+}
+
+func TestResolveYouTubeChannelIDBySourceMissingAPIKey(t *testing.T) {
+	t.Setenv("YOUTUBE_API_KEY", "")
+	_, err := resolveYouTubeChannelIDBySource("https://www.youtube.com/watch?v=abcdefghijk")
+	if err == nil {
+		t.Fatalf("expected missing key error")
+	}
+	if !strings.Contains(err.Error(), "YOUTUBE_API_KEY") {
+		t.Fatalf("expected YOUTUBE_API_KEY error, got %v", err)
+	}
+}
+
 func TestMessagePayloadFromStorageEnrichesTwitchSubscriberViaSourceChannelFallback(t *testing.T) {
 	const (
 		testClientID     = "test-client-id"

--- a/src/backend/routes/config.go
+++ b/src/backend/routes/config.go
@@ -40,8 +40,9 @@ var runtimeState = struct {
 }
 
 var runtimeHooks = struct {
-	mu          sync.RWMutex
-	applyTailer func(runtimeconfig.TailerConfig) error
+	mu                   sync.RWMutex
+	applyTailer          func(runtimeconfig.TailerConfig) error
+	applyThirdPartyEmote func(runtimeconfig.Config) error
 }{}
 
 // RegisterTailerConfigApplier sets a hot-apply hook for runtime tailer updates.
@@ -51,9 +52,26 @@ func RegisterTailerConfigApplier(fn func(runtimeconfig.TailerConfig) error) {
 	runtimeHooks.applyTailer = fn
 }
 
+// RegisterThirdPartyEmoteReloader sets the hot-apply hook for channel-aware emote cache reloads.
+func RegisterThirdPartyEmoteReloader(fn func(runtimeconfig.Config) error) {
+	runtimeHooks.mu.Lock()
+	defer runtimeHooks.mu.Unlock()
+	runtimeHooks.applyThirdPartyEmote = fn
+}
+
 func applyTailerConfig(cfg runtimeconfig.TailerConfig) error {
 	runtimeHooks.mu.RLock()
 	fn := runtimeHooks.applyTailer
+	runtimeHooks.mu.RUnlock()
+	if fn == nil {
+		return nil
+	}
+	return fn(cfg)
+}
+
+func applyThirdPartyEmoteReload(cfg runtimeconfig.Config) error {
+	runtimeHooks.mu.RLock()
+	fn := runtimeHooks.applyThirdPartyEmote
 	runtimeHooks.mu.RUnlock()
 	if fn == nil {
 		return nil
@@ -272,6 +290,17 @@ func handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	runtimeState.mu.Lock()
 	runtimeState.current = normalized
 	runtimeState.mu.Unlock()
+
+	if previous.TwitchChannel != normalized.TwitchChannel || previous.YouTubeSourceURL != normalized.YouTubeSourceURL {
+		if err := applyThirdPartyEmoteReload(normalized); err != nil {
+			log.Printf(
+				"config: third-party emote reload warning twitch_channel=%q youtube_source=%q err=%v",
+				normalized.TwitchChannel,
+				normalized.YouTubeSourceURL,
+				err,
+			)
+		}
+	}
 
 	syncGnastyConfigBestEffort(normalized, "put")
 

--- a/src/backend/routes/config_test.go
+++ b/src/backend/routes/config_test.go
@@ -41,6 +41,7 @@ func resetRuntimeConfigForTest(t *testing.T) {
 		overrideWSEnvelope = nil
 		overrideWSDropEmpty = nil
 		RegisterTailerConfigApplier(nil)
+		RegisterThirdPartyEmoteReloader(nil)
 	})
 }
 
@@ -570,6 +571,83 @@ func TestPutConfigNoopAllowsEmptyOptionalSources(t *testing.T) {
 	}
 	if updated.Changed {
 		t.Fatalf("expected changed=false for no-op put")
+	}
+}
+
+func TestPutConfigReloadsThirdPartyEmotesOnSourceChange(t *testing.T) {
+	resetRuntimeConfigForTest(t)
+	cleanup := withSQLiteStore(t)
+	defer cleanup()
+
+	InitRoutes(chatStore)
+	router := newConfigRouter()
+
+	var reloadCalls atomic.Int32
+	RegisterThirdPartyEmoteReloader(func(runtimeconfig.Config) error {
+		reloadCalls.Add(1)
+		return nil
+	})
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	getRR := httptest.NewRecorder()
+	router.ServeHTTP(getRR, getReq)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("expected get 200, got %d body=%s", getRR.Code, getRR.Body.String())
+	}
+
+	var current configAPIResponse
+	if err := json.Unmarshal(getRR.Body.Bytes(), &current); err != nil {
+		t.Fatalf("decode current config: %v", err)
+	}
+	current.Config.TwitchChannel = "dagnel"
+	body, _ := json.Marshal(current.Config)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/config", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := reloadCalls.Load(); got != 1 {
+		t.Fatalf("expected one emote reload call, got %d", got)
+	}
+}
+
+func TestPutConfigNoopDoesNotReloadThirdPartyEmotes(t *testing.T) {
+	resetRuntimeConfigForTest(t)
+	cleanup := withSQLiteStore(t)
+	defer cleanup()
+
+	InitRoutes(chatStore)
+	router := newConfigRouter()
+
+	var reloadCalls atomic.Int32
+	RegisterThirdPartyEmoteReloader(func(runtimeconfig.Config) error {
+		reloadCalls.Add(1)
+		return nil
+	})
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	getRR := httptest.NewRecorder()
+	router.ServeHTTP(getRR, getReq)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("expected get 200, got %d body=%s", getRR.Code, getRR.Body.String())
+	}
+
+	var current configAPIResponse
+	if err := json.Unmarshal(getRR.Body.Bytes(), &current); err != nil {
+		t.Fatalf("decode current config: %v", err)
+	}
+	body, _ := json.Marshal(current.Config)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/config", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := reloadCalls.Load(); got != 0 {
+		t.Fatalf("expected no emote reload for no-op put, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make third-party emote loading channel-aware in `elora-chat` backend.
- Keep `emodl`, but remove hardcoded Twitch ID usage.
- Resolve Twitch broadcaster ID from runtime `twitchChannel`.
- Resolve YouTube channel ID from runtime `youtubeSourceUrl` (best-effort via `YOUTUBE_API_KEY`).
- Reload emote cache at startup and on `PUT /api/config` source changes.
- Keep previous cache on reload failure and log warnings.
- Add tests for YouTube source resolution and config-triggered emote reload behavior.
- Add docs + utility script for Docker Compose plugin crash recovery on Ubuntu.

## How to verify
1. `GET /api/config` and note current `twitchChannel`/`youtubeSourceUrl`.
2. `PUT /api/config` with a different `twitchChannel`; check logs for:
   - `emodl: reload targets ...`
   - `emodl: cache size = ...`
3. `PUT /api/config` with a different `youtubeSourceUrl`; check same reload logs.
4. Open UI and send/view messages for the selected channel/source; confirm third-party emotes are tokenized/rendered.
5. Confirm no reload occurs on no-op `PUT /api/config`.

## Test status
Tests: pass (backend routes, backend all, frontend unit, gnasty go test)