### PR TITLE
Add dylan rollout target across deploy, Caddy, docs, and validation

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -1,4 +1,4 @@
-# Production template (copy into deploy/.env.prod.dayo and deploy/.env.prod.test)
+# Production template (copy into deploy/.env.prod.dayo, deploy/.env.prod.test, and deploy/.env.prod.dylan)
 
 # Global
 TZ=America/Phoenix

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -21,3 +21,15 @@ elora.hayden.it.com {
 
   reverse_proxy elora_test-elora-chat:8080
 }
+
+dylan.hayden.it.com {
+  encode zstd gzip
+
+  header {
+    X-Content-Type-Options nosniff
+    Referrer-Policy strict-origin-when-cross-origin
+    X-Frame-Options SAMEORIGIN
+  }
+
+  reverse_proxy elora_dylan-elora-chat:8080
+}

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -10,11 +10,12 @@ ACTION="deploy"
 
 usage() {
   cat <<'EOF'
-Usage: ./deploy/update.sh --target <dayo|test|edge> [--action <deploy|status|logs>] [--no-git]
+Usage: ./deploy/update.sh --target <dayo|test|dylan|edge> [--action <deploy|status|logs>] [--no-git]
 
 Targets:
   dayo  Update dayo.hayden.it.com app stack (elora-chat + gnasty-harvester)
   test  Update elora.hayden.it.com app stack (elora-chat + gnasty-harvester)
+  dylan Update dylan.hayden.it.com app stack (elora-chat + gnasty-harvester)
   edge  Update shared Caddy edge router stack
 
 Flags:
@@ -61,6 +62,12 @@ case "${TARGET}" in
   test)
     ENV_FILE="deploy/.env.prod.test"
     APP_HOST="elora.hayden.it.com"
+    COMPOSE_ARGS=(-f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file "${ENV_FILE}")
+    SERVICES=(elora-chat gnasty-harvester)
+    ;;
+  dylan)
+    ENV_FILE="deploy/.env.prod.dylan"
+    APP_HOST="dylan.hayden.it.com"
     COMPOSE_ARGS=(-f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file "${ENV_FILE}")
     SERVICES=(elora-chat gnasty-harvester)
     ;;

--- a/deploy/validate-rollout.sh
+++ b/deploy/validate-rollout.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Non-mutating rollout validation for edge + dayo/test/dylan stacks.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+DAYO_DOMAIN="${DAYO_DOMAIN:-dayo.hayden.it.com}"
+TEST_DOMAIN="${TEST_DOMAIN:-elora.hayden.it.com}"
+DYLAN_DOMAIN="${DYLAN_DOMAIN:-dylan.hayden.it.com}"
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need_cmd curl
+need_cmd jq
+need_cmd docker
+
+check_http() {
+  local domain="$1"
+  echo "== ${domain}: health checks =="
+  curl -fsS "https://${domain}/healthz" >/dev/null
+  curl -fsS "https://${domain}/readyz" >/dev/null
+  echo "ok: healthz/readyz"
+}
+
+check_runtime() {
+  local domain="$1"
+  echo "== ${domain}: runtime checks =="
+  curl -fsS "https://${domain}/api/config" \
+    | jq '.config | {apiBaseUrl,wsUrl,twitchChannel,youtubeSourceUrl}'
+  curl -fsS "https://${domain}/configz" \
+    | jq '{tailer,gnasty_sync}'
+}
+
+check_compose_target() {
+  local target="$1"
+  echo "== compose target: ${target} =="
+  ./deploy/update.sh --target "${target}" --action status
+}
+
+check_container_dns() {
+  local container="$1"
+  echo "== container dns: ${container} =="
+  docker inspect "${container}" --format '{{json .HostConfig.DNS}}'
+}
+
+echo "== 1) Compose status =="
+check_compose_target edge
+check_compose_target dayo
+check_compose_target test
+check_compose_target dylan
+
+echo
+echo "== 2) External endpoint checks =="
+check_http "${DAYO_DOMAIN}"
+check_http "${TEST_DOMAIN}"
+check_http "${DYLAN_DOMAIN}"
+
+echo
+echo "== 3) Runtime snapshots =="
+check_runtime "${DAYO_DOMAIN}"
+check_runtime "${TEST_DOMAIN}"
+check_runtime "${DYLAN_DOMAIN}"
+
+echo
+echo "== 4) Container DNS settings =="
+check_container_dns elora_dayo-elora-chat
+check_container_dns elora_test-elora-chat
+check_container_dns elora_dylan-elora-chat
+
+echo
+echo "Validation complete."

--- a/docs/backup-server.md
+++ b/docs/backup-server.md
@@ -1,9 +1,10 @@
-# Split Domains on One Host (Prod + Test + Shared Caddy)
+# Split Domains on One Host (Prod + Test + Dylan + Shared Caddy)
 
-This guide runs two isolated Elora stacks on one Ubuntu host:
+This guide runs three isolated Elora stacks on one Ubuntu host:
 
 - `https://dayo.hayden.it.com` (prod/dayoman-focused)
 - `https://elora.hayden.it.com` (test/sandbox)
+- `https://dylan.hayden.it.com` (dylan target)
 
 Isolation is infrastructure-only:
 
@@ -26,6 +27,7 @@ Add `A` records:
 
 - `dayo` -> server public IP
 - `elora` -> server public IP
+- `dylan` -> server public IP
 
 If your host is IPv4-only, remove any `AAAA` records for these hosts to avoid IPv6 resolution failures.
 
@@ -34,6 +36,7 @@ Verify DNS propagation:
 ```bash
 dig +short dayo.hayden.it.com
 dig +short elora.hayden.it.com
+dig +short dylan.hayden.it.com
 ```
 
 ## 3. Repo Setup
@@ -53,8 +56,9 @@ This repo now ships:
 
 - `deploy/.env.prod.dayo`
 - `deploy/.env.prod.test`
+- `deploy/.env.prod.dylan`
 
-Edit both files before first deploy:
+Edit all three files before first deploy:
 
 - `GNASTY_IMAGE`
 - Twitch OAuth client ID/secret
@@ -65,16 +69,17 @@ Edit both files before first deploy:
 Ensure host data paths exist and are writable:
 
 ```bash
-sudo mkdir -p /data_dayo /data_test
-sudo chown -R "$USER":"$USER" /data_dayo /data_test
+sudo mkdir -p /data_dayo /data_test /data_dylan
+sudo chown -R "$USER":"$USER" /data_dayo /data_test /data_dylan
 ```
 
 ## 5. Twitch OAuth Redirect URIs
 
-In Twitch dev console, add both exact callbacks:
+In Twitch dev console, add all exact callbacks:
 
 - `https://dayo.hayden.it.com/callback/twitch`
 - `https://elora.hayden.it.com/callback/twitch`
+- `https://dylan.hayden.it.com/callback/twitch`
 
 ## 6. Bring Up Stacks
 
@@ -96,6 +101,12 @@ In Twitch dev console, add both exact callbacks:
 ./deploy/update.sh --target test
 ```
 
+4. Start dylan app stack:
+
+```bash
+./deploy/update.sh --target dylan
+```
+
 ## 7. Verify
 
 ```bash
@@ -103,6 +114,8 @@ curl -fsS https://dayo.hayden.it.com/healthz; echo
 curl -fsS https://dayo.hayden.it.com/readyz; echo
 curl -fsS https://elora.hayden.it.com/healthz; echo
 curl -fsS https://elora.hayden.it.com/readyz; echo
+curl -fsS https://dylan.hayden.it.com/healthz; echo
+curl -fsS https://dylan.hayden.it.com/readyz; echo
 ```
 
 Check per-domain runtime config:
@@ -110,6 +123,7 @@ Check per-domain runtime config:
 ```bash
 curl -fsS https://dayo.hayden.it.com/api/config | jq '.config | {twitchChannel,youtubeSourceUrl,apiBaseUrl,wsUrl}'
 curl -fsS https://elora.hayden.it.com/api/config | jq '.config | {twitchChannel,youtubeSourceUrl,apiBaseUrl,wsUrl}'
+curl -fsS https://dylan.hayden.it.com/api/config | jq '.config | {twitchChannel,youtubeSourceUrl,apiBaseUrl,wsUrl}'
 ```
 
 Check gnasty sync telemetry in `/configz`:
@@ -117,12 +131,13 @@ Check gnasty sync telemetry in `/configz`:
 ```bash
 curl -fsS https://dayo.hayden.it.com/configz | jq '.gnasty_sync'
 curl -fsS https://elora.hayden.it.com/configz | jq '.gnasty_sync'
+curl -fsS https://dylan.hayden.it.com/configz | jq '.gnasty_sync'
 ```
 
 ## 8. Isolation Validation
 
 1. Change source/channel on `elora.hayden.it.com`.
-2. Confirm `dayo.hayden.it.com/api/config` is unchanged.
+2. Confirm both `dayo.hayden.it.com/api/config` and `dylan.hayden.it.com/api/config` are unchanged.
 3. Restart only test stack:
 
 ```bash
@@ -137,16 +152,18 @@ Run this divergence check to prove live source isolation:
 # Show distinct runtime source targets
 curl -fsS https://dayo.hayden.it.com/api/config | jq '.config | {twitchChannel,youtubeSourceUrl}'
 curl -fsS https://elora.hayden.it.com/api/config | jq '.config | {twitchChannel,youtubeSourceUrl}'
+curl -fsS https://dylan.hayden.it.com/api/config | jq '.config | {twitchChannel,youtubeSourceUrl}'
 
 # Sample latest persisted messages per domain (author/platform/text preview)
 curl -fsS 'https://dayo.hayden.it.com/api/messages?limit=5' | jq '.items[] | {platform,username,text}'
 curl -fsS 'https://elora.hayden.it.com/api/messages?limit=5' | jq '.items[] | {platform,username,text}'
+curl -fsS 'https://dylan.hayden.it.com/api/messages?limit=5' | jq '.items[] | {platform,username,text}'
 ```
 
 If either stack drifts from its expected source/channel after restart, force a no-op re-sync:
 
 ```bash
-for DOMAIN in dayo.hayden.it.com elora.hayden.it.com; do
+for DOMAIN in dayo.hayden.it.com elora.hayden.it.com dylan.hayden.it.com; do
   cfg="$(curl -fsS "https://$DOMAIN/api/config" | jq '.config')"
   curl -fsS -X PUT "https://$DOMAIN/api/config" -H 'Content-Type: application/json' --data "$cfg" >/dev/null
 done
@@ -160,10 +177,12 @@ Status/logs by target:
 ./deploy/update.sh --target edge --action status
 ./deploy/update.sh --target dayo --action status
 ./deploy/update.sh --target test --action status
+./deploy/update.sh --target dylan --action status
 
 ./deploy/update.sh --target edge --action logs
 ./deploy/update.sh --target dayo --action logs
 ./deploy/update.sh --target test --action logs
+./deploy/update.sh --target dylan --action logs
 ```
 
 Direct compose inspection:
@@ -172,6 +191,13 @@ Direct compose inspection:
 docker compose -f deploy/docker-compose.edge.yml --env-file deploy/.env.prod.test -p elora_edge ps
 docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file deploy/.env.prod.dayo ps
 docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file deploy/.env.prod.test ps
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file deploy/.env.prod.dylan ps
+```
+
+Run the rollout validation script:
+
+```bash
+bash deploy/validate-rollout.sh
 ```
 
 ## 10. Troubleshooting
@@ -182,12 +208,13 @@ docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-fil
   - Confirm container names resolve:
     - `elora_dayo-elora-chat`
     - `elora_test-elora-chat`
+    - `elora_dylan-elora-chat`
 - OAuth redirect mismatch:
   - Callback in env must exactly match Twitch console URI.
 - CORS errors:
   - Verify `ELORA_ALLOWED_ORIGINS` and `ELORA_WS_ALLOWED_ORIGINS` per domain.
 - Permission errors on SQLite/token handoff:
-  - Verify ownership and write perms on `/data_dayo` and `/data_test`.
+  - Verify ownership and write perms on `/data_dayo`, `/data_test`, and `/data_dylan`.
 - Tailer updates via `PUT /api/config`:
   - Tailer changes now hot-apply immediately and should appear in `/configz` without restarting the stack.
   - Ingest process settings still require a stack restart for full effect.


### PR DESCRIPTION
## Summary
Adds a new `dylan` rollout target to the split-stack deployment setup so `dylan.hayden.it.com` can be managed alongside `dayo` and `elora`.

## Included changes
- Added `dylan` target support in `deploy/update.sh`
  - `--target dylan` now resolves to `deploy/.env.prod.dylan`
  - Health check host is `https://dylan.hayden.it.com/readyz`
- Updated `deploy/Caddyfile`
  - Added `dylan.hayden.it.com` reverse proxy to `elora_dylan-elora-chat:8080`
- Updated `deploy/.env.prod.example`
  - Template header now includes `.env.prod.dylan`
- Updated `docs/backup-server.md`
  - Expanded from 2-stack to 3-stack docs (`dayo`, `elora`, `dylan`)
  - Added DNS/OAuth/data-dir/deploy/verify/status/log commands for dylan
  - Added rollout validation script usage
- Added `deploy/validate-rollout.sh`
  - Non-mutating checks for edge + dayo/test/dylan (compose status, health, runtime snapshot, container DNS)

## How to verify
1. Deploy edge and dylan:
   - `./deploy/update.sh --target edge --no-git`
   - `./deploy/update.sh --target dylan --no-git`
2. Run validation:
   - `bash deploy/validate-rollout.sh`
3. Confirm dylan endpoint health:
   - `curl -fsS https://dylan.hayden.it.com/readyz`